### PR TITLE
r55: add ETHBridge and SignalService contracts/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,19 @@ running two transactions on it, first a `mint` then a `balance_of` check.
 You'll need to install Rust's RISCV toolchain:
 
 ```console
-$ rustup install nightly-2024-02-01-x86_64-unknown-linux-gnu
+$ rustup install nightly-2025-01-07
+$ rustup target add riscv64imac-unknown-none-elf --toolchain nightly-2025-01-07
 ```
+
+**Note:** The project now automatically uses the correct toolchain via `rust-toolchain.toml`. You can simply run `cargo test` without manual toolchain switching.
 
 Now run:
 
 ```console
 $ cargo test --package r55 --test e2e -- erc20 --exact --show-output
+
+**Note:** You can now use simple cargo commands like `cargo test --test e2e` without the nightly prefix!
+
 ...
 Compiling deploy: erc20
 Cargo command completed successfully
@@ -167,4 +173,60 @@ graph TD;
     revm --> revm-r55
     rvemu-r55 --> revm-r55
     eth-riscv-runtime --> revm-r55
+
+# Development
+
+## Quick Start
+
+This project automatically uses the required Rust nightly toolchain. Simply clone and run:
+
+```bash
+# Clone the repository
+git clone <your-repo-url>
+cd r55
+
+# Run tests
+cargo test
+
+# Build the project
+cargo build
+
+# Compile contracts
+cd r55-compile
+cargo run
 ```
+
+## Available Commands
+
+```bash
+# Run all tests
+cargo test
+
+# Run specific test files
+cargo test --test e2e
+cargo test --test erc20
+cargo test --test erc721
+
+# Build the project
+cargo build
+
+# Clean build artifacts
+cargo clean
+
+# Compile all contracts (generates bytecode)
+cd r55-compile
+cargo run
+```
+
+## Project Structure
+
+- `examples/` - Example smart contracts (ERC20, ERC721, etc.)
+- `r55/` - Main R55 runtime and tests
+- `r55-compile/` - Contract compilation tool
+- `r55-output-bytecode/` - Generated contract bytecode
+- `contract-derive/` - Contract macro implementation
+- `eth-riscv-runtime/` - RISC-V runtime for smart contracts
+
+## Toolchain Requirements
+
+The project automatically uses Rust nightly-2025-01-07 with RISC-V target support. No manual toolchain switching is required.

--- a/examples/hydra-l2-bridge/Cargo.toml
+++ b/examples/hydra-l2-bridge/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "hydra-l2-bridge"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[features]
+default = []
+deploy = []
+interface-only = []
+
+[dependencies]
+contract-derive = { path = "../../contract-derive" }
+eth-riscv-runtime = { path = "../../eth-riscv-runtime" }
+
+alloy-core = { version = "1.3.1", default-features = false }
+alloy-sol-types = { version = "1.3.1", default-features = false }
+
+[[bin]]
+name = "runtime"
+path = "src/lib.rs"
+
+[[bin]]
+name = "deploy"
+path = "src/lib.rs"
+required-features = ["deploy"]
+
+[profile.release]
+lto = true
+opt-level = "z"

--- a/examples/hydra-l2-bridge/src/deployable.rs
+++ b/examples/hydra-l2-bridge/src/deployable.rs
@@ -1,0 +1,10 @@
+//! Auto-generated based on Cargo.toml dependencies
+//! This file provides Deployable implementations for contract dependencies
+//! TODO (phase-2): rather than using `fn deploy(args: Args)`, figure out the constructor selector from the contract dependency
+
+use alloy_core::primitives::{Address, Bytes};
+use eth_riscv_runtime::{create::Deployable, InitInterface, ReadOnly};
+use core::include_bytes;
+
+
+

--- a/examples/hydra-l2-bridge/src/lib.rs
+++ b/examples/hydra-l2-bridge/src/lib.rs
@@ -1,0 +1,255 @@
+#![no_std]
+#![no_main]
+//! ETHBridge (R55/RISC-V)
+//!
+//! Cross-chain ETH bridge mirroring the Solidity reference implementation.
+//! - Deposits: records an `ETHDeposit`, signals the deposit id via `SignalService`,
+//!   and emits `DepositMade`.
+//! - Claims/Cancels: requires a verified signal from the counterpart chain via
+//!   `SignalService.verifySignal` and enforces replay protection via `processed`.
+//! - Value transfer: uses runtime `call_contract` and intentionally ignores
+//!   returndata (no success flag), matching the reference’s semantics.
+
+use alloy_core::primitives::{keccak256 as alloy_keccak256, Address, Bytes, FixedBytes, U256};
+use contract_derive::{contract, interface, payable, storage, Event};
+use eth_riscv_runtime::{msg_sender, msg_value, call_contract};
+use eth_riscv_runtime::types::*;
+
+type B32 = FixedBytes<32>;
+
+extern crate alloc;
+
+/// ETHDeposit struct matching Solidity interface
+#[derive(Clone, Debug, Default)]
+pub struct ETHDeposit {
+    pub nonce: U256,
+    pub from: Address,
+    pub to: Address,
+    pub amount: U256,
+    pub data: Bytes,
+    pub context: Bytes,
+    pub canceler: Address,
+}
+
+impl ETHDeposit {
+    pub fn new(
+        nonce: U256,
+        from: Address,
+        to: Address,
+        amount: U256,
+        data: Bytes,
+        context: Bytes,
+        canceler: Address,
+    ) -> Self {
+        Self {
+            nonce,
+            from,
+            to,
+            amount,
+            data,
+            context,
+            canceler,
+        }
+    }
+}
+
+// Event: DepositMade(bytes32 indexed id, ETHDeposit deposit)
+#[derive(Event)]
+struct DepositMade {
+    #[indexed]
+    id: B32,
+    // Represent Solidity struct as a tuple in the same field order
+    deposit: (U256, Address, Address, U256, Bytes, Bytes, Address),
+}
+
+// Event: DepositClaimed(bytes32 indexed id, ETHDeposit deposit)
+#[derive(Event)]
+struct DepositClaimed {
+    #[indexed]
+    id: B32,
+    deposit: (U256, Address, Address, U256, Bytes, Bytes, Address),
+}
+
+// Event: DepositCancelled(bytes32 indexed id, address claimee)
+#[derive(Event)]
+struct DepositCancelled {
+    #[indexed]
+    id: B32,
+    claimee: Address,
+}
+
+#[interface("camelCase")]
+trait ISignalService {
+    fn sendSignal(&mut self, value: B32) -> B32;
+    fn verifySignal(&self, sender: Address, value: B32, proof: Bytes);
+}
+
+/// Storage
+#[storage]
+pub struct ETHBridge {
+    processed: Mapping<B32, Slot<U256>>, // 1 == processed
+    global_deposit_nonce: Slot<U256>,
+    signal_service: Slot<Address>,
+    counterpart: Slot<Address>,
+}
+
+#[contract]
+impl ETHBridge {
+    pub fn new(signal_service: Address, counterpart: Address) -> Self {
+        if signal_service == Address::ZERO || counterpart == Address::ZERO {
+            revert();
+        }
+
+        let mut s = ETHBridge::default();
+        s.signal_service.write(signal_service);
+        s.counterpart.write(counterpart);
+        s
+    }
+
+    // processed(bytes32) -> bool — replay protection state
+    pub fn processed(&self, id: B32) -> bool {
+        // Solidity mapping(bytes32 => bool) parity: store 1 for true, 0 for false
+        self.processed[id].read() == U256::from(1u8)
+    }
+
+    // getDepositId(ETHDeposit) -> bytes32 (Solidity abi.encode struct hashing)
+    pub fn getDepositId(
+        &self,
+        eth_deposit: (U256, Address, Address, U256, Bytes, Bytes, Address),
+    ) -> B32 {
+        // keccak256(abi.encode(ETHDeposit)) using alloy ABI encoder for exact Solidity parity
+        // Normally for multiple params we use abi_encode_params, but this is a struct so we use abi_encode
+        B32::from(alloy_keccak256(&alloy_sol_types::SolValue::abi_encode(
+            &eth_deposit,
+        )))
+    }
+
+    // deposit(address to, bytes data, bytes context, address canceler) -> bytes32
+    // Increments global nonce, posts a signal to SignalService, and emits `DepositMade`.
+    #[payable]
+    pub fn deposit(&mut self, to: Address, data: Bytes, context: Bytes, canceler: Address) -> B32 {
+        let from = msg_sender();
+        let amount = msg_value();
+        let nonce = self.global_deposit_nonce.read();
+
+        // Solidity struct as tuple
+        let deposit_t = (nonce, from, to, amount, data, context, canceler);
+        let id = self.getDepositId(deposit_t.clone());
+
+        // ++_globalDepositNonce (wrap-free increment)
+        self.global_deposit_nonce.write(nonce + U256::from(1));
+
+        // signal the deposit id on SignalService: sendSignal(bytes32)
+        let sig_addr = self.signal_service.read();
+        let _ = ISignalService::new(sig_addr).with_ctx(self).sendSignal(id);
+
+        // emit DepositMade(id, ethDeposit)
+        log::emit(DepositMade::new(id, deposit_t));
+
+        id
+    }
+
+    // claimDeposit(ETHDeposit, bytes proof)
+    // Verifies counterpart signal via `SignalService.verifySignal`, marks processed,
+    // and transfers ETH to recipient with user-supplied calldata.
+    pub fn claimDeposit(&mut self, eth_deposit: (U256, Address, Address, U256, Bytes, Bytes, Address), proof: Bytes) {
+        // get the deposit id
+        let id = self.getDepositId(eth_deposit.clone());
+
+        // check if the id is already processed
+        if self.processed[id].read() == U256::from(1u8) {
+            revert_selector(selector_already_claimed());
+        }
+
+        // verify the signal on SignalService
+        let signal_service = self.signal_service.read();
+        let counterpart = self.counterpart.read();
+        let _ = ISignalService::new(signal_service).with_ctx(&*self).verifySignal(counterpart, id, proof);
+
+        // mark the id as processed
+        self.processed[id].write(U256::from(1u8));
+
+        // transfer ETH to the specified `to` using R55 runtime call
+        let to = eth_deposit.2;
+        let amount_be = eth_deposit.3.to_be_bytes::<32>();
+        // reject amounts that don't fit into u64 (runtime call ABI constraint)
+        if amount_be[..24].iter().any(|&b| b != 0) {
+            revert_selector(selector_failed_claim());
+        }
+        let amount = u64::from_be_bytes(amount_be[24..32].try_into().unwrap());
+        let data = eth_deposit.4.clone();
+        // perform CALL with value; returndata ignored (no success flag available)
+        let _ = call_contract(to, amount, &data, None);
+
+        // emit DepositClaimed(id, ethDeposit)
+        eth_riscv_runtime::log::emit(DepositClaimed::new(id, eth_deposit));
+    }
+
+    // cancelDeposit(ETHDeposit, address claimee, bytes proof)
+    // Only the designated canceler can cancel; verifies signal and pays `claimee`.
+    pub fn cancelDeposit(
+        &mut self,
+        eth_deposit: (U256, Address, Address, U256, Bytes, Bytes, Address),
+        claimee: Address,
+        proof: Bytes,
+    ) {
+        // only canceler can cancel
+        if msg_sender() != eth_deposit.6 {
+            revert_selector(selector_only_canceler());
+        }
+
+        // derive id and reject already-processed
+        let id = self.getDepositId(eth_deposit.clone());
+        if self.processed[id].read() == U256::from(1u8) {
+            revert_selector(selector_already_claimed());
+        }
+
+        // verify the signal on SignalService
+        let signal_service = self.signal_service.read();
+        let counterpart = self.counterpart.read();
+        let _ = ISignalService::new(signal_service).with_ctx(&*self).verifySignal(counterpart, id, proof);
+
+        // mark processed
+        self.processed[id].write(U256::from(1u8));
+
+        // send ETH to claimee with empty data
+        let amount_be = eth_deposit.3.to_be_bytes::<32>();
+        if amount_be[..24].iter().any(|&b| b != 0) {
+            revert_selector(selector_failed_claim());
+        }
+        let amount = u64::from_be_bytes(amount_be[24..32].try_into().unwrap());
+        let empty = Bytes::new();
+
+        let _ = call_contract(claimee, amount, &empty, None);
+
+        // emit DepositCancelled(id, claimee)
+        log::emit(DepositCancelled::new(id, claimee));
+    }
+}
+
+// --- Internals ---
+
+fn revert_selector(sel: [u8; 4]) -> ! {
+    revert_with_error(&sel)
+}
+
+fn selector_already_claimed() -> [u8; 4] {
+    // keccak256("AlreadyClaimed()")[:4]
+    let sig = b"AlreadyClaimed()";
+    let h = alloy_keccak256(sig);
+    [h[0], h[1], h[2], h[3]]
+}
+
+fn selector_failed_claim() -> [u8; 4] {
+    // keccak256("FailedClaim()")[:4]
+    let sig = b"FailedClaim()";
+    let h = alloy_keccak256(sig);
+    [h[0], h[1], h[2], h[3]]
+}
+
+fn selector_only_canceler() -> [u8; 4] {
+    // keccak256("OnlyCanceler()")[:4]
+    let sig = b"OnlyCanceler()";
+    let h = alloy_keccak256(sig);
+    [h[0], h[1], h[2], h[3]]
+}

--- a/examples/hydra-l2-signal-service/Cargo.toml
+++ b/examples/hydra-l2-signal-service/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "hydra-l2-signal-service"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[features]
+default = []
+deploy = []
+interface-only = []
+
+[dependencies]
+contract-derive = { path = "../../contract-derive" }
+eth-riscv-runtime = { path = "../../eth-riscv-runtime" }
+
+alloy-core = { version = "1.3.1", default-features = false }
+alloy-sol-types = { version = "1.3.1", default-features = false }
+alloy-rlp = { version = "0.3.12", default-features = false }
+alloy-trie = { version = "0.9.1", default-features = false }
+nybbles = { version = "0.4.5", default-features = false }
+
+[[bin]]
+name = "runtime"
+path = "src/lib.rs"
+
+[[bin]]
+name = "deploy"
+path = "src/lib.rs"
+required-features = ["deploy"]
+
+[profile.release]
+lto = true
+opt-level = "z"

--- a/examples/hydra-l2-signal-service/src/deployable.rs
+++ b/examples/hydra-l2-signal-service/src/deployable.rs
@@ -1,0 +1,10 @@
+//! Auto-generated based on Cargo.toml dependencies
+//! This file provides Deployable implementations for contract dependencies
+//! TODO (phase-2): rather than using `fn deploy(args: Args)`, figure out the constructor selector from the contract dependency
+
+use alloy_core::primitives::{Address, Bytes};
+use eth_riscv_runtime::{create::Deployable, InitInterface, ReadOnly};
+use core::include_bytes;
+
+
+

--- a/examples/hydra-l2-signal-service/src/lib.rs
+++ b/examples/hydra-l2-signal-service/src/lib.rs
@@ -1,0 +1,207 @@
+#![no_std]
+#![no_main]
+//! SignalService (R55/RISC-V)
+//!
+//! Secure signaling and verification utility used by the bridge.
+//! - sendSignal: marks a namespaced storage slot `(value,sender)` per ERC‑7201
+//!   derivation and emits `SignalSent`.
+//! - isSignalStored: reads the same namespaced slot.
+//! - verifySignal: requires the state root to be signaled by a trusted publisher,
+//!   verifies account/storage proofs against that root, then emits `SignalVerified`.
+
+use alloy_core::primitives::{keccak256 as alloy_keccak256, Address, Bytes, FixedBytes, U256, B256};
+use contract_derive::{contract, storage, Event};
+use eth_riscv_runtime::msg_sender;
+use eth_riscv_runtime::types::*;
+
+type B32 = FixedBytes<32>;
+
+extern crate alloc;
+use alloc::vec::Vec;
+use eth_riscv_runtime::{revert_with_error, revert};
+use nybbles::Nibbles;
+use alloy_trie::proof::{verify_proof, ProofVerificationError};
+use alloy_rlp::Decodable;
+// RLP helpers via derive decoding for specific proof node shapes
+
+// SignalSent(address indexed sender, bytes32 value)
+#[derive(Event)]
+struct SignalSent {
+    #[indexed]
+    sender: Address,
+    value: B32,
+}
+
+// SignalVerified(address indexed sender, bytes32 value)
+#[derive(Event)]
+struct SignalVerified {
+    #[indexed]
+    sender: Address,
+    value: B32,
+}
+
+#[storage]
+pub struct SignalService {
+    state_root_publisher: Slot<Address>,
+    this_address: Slot<Address>,
+    signals: Mapping<B32, Slot<bool>>,
+}
+
+#[contract]
+impl SignalService {
+    pub fn new(state_root_publisher: Address, _this_address: Address) -> Self {
+        let mut s = SignalService::default();
+        s.state_root_publisher.write(state_root_publisher);
+        s.this_address.write(_this_address);
+        s
+    }
+
+    pub fn sendSignal(&mut self, value: B32) -> B32 {
+        let sender = msg_sender();
+        let slot = derive_key(value, sender);
+
+        self.signals[slot].write(true);
+        log::emit(SignalSent::new(sender, value));
+
+        slot
+    }
+
+    pub fn isSignalStored(&self, value: B32, sender: Address) -> bool {
+        let slot = derive_key(value, sender);
+        self.signals[slot].read()
+    }
+
+    pub fn verifySignal(&self, sender: Address, value: B32, proof_bytes: Bytes) {
+        // Decode SignalProof(accountProof, storageProof, stateRoot)
+        // Only perform state-root gating and non-empty accountProof check for now.
+        alloy_sol_types::sol! {
+            struct SignalProof { bytes[] accountProof; bytes[] storageProof; bytes32 stateRoot; }
+        }
+
+        let Ok(signal_proof) = <SignalProof as alloy_sol_types::SolType>::abi_decode(&proof_bytes) else {
+            // If decoding fails, mirror Solidity's behavior: generic revert
+            revert();
+        };
+
+        let account_proof: Vec<Bytes> = signal_proof.accountProof;
+        let storage_proof: Vec<Bytes> = signal_proof.storageProof;
+        let state_root_b32: B32 = signal_proof.stateRoot;
+
+        // State root must be signaled by the publisher
+        let publisher = self.state_root_publisher.read();
+        let state_root_slot = derive_key(state_root_b32, publisher);
+        if !self.signals[state_root_slot].read() {
+            revert_selector(selector_state_root_not_found());
+        }
+
+        // accountProof must be non-empty
+        if account_proof.is_empty() {
+            revert_selector(selector_account_proof_empty());
+        }
+        // Retrieve the SignalService account's storage root from the proven account against state root.
+        // We assume cross-chain deployments at the same address; the constructor provided `_this_address`.
+        let this_addr = self.this_address.read();
+
+        // Verify account proof against the state root, retrieve the RLP-encoded account value.
+        // Strategy: call verify_proof with expected_value None and recover the proven value from the
+        // ValueMismatch error variant which includes the actual leaf value when present.
+        let state_root = B256::from_slice(state_root_b32.as_slice());
+        let account_key = Nibbles::unpack(alloy_keccak256(this_addr.as_slice()).as_slice());
+        let account_proof_iter = account_proof.iter();
+
+        let account_rlp: Vec<u8> = match verify_proof(state_root, account_key, None, account_proof_iter) {
+            Ok(()) => {
+                // Account does not exist (non-inclusion). Treat as invalid account proof.
+                revert_selector(selector_invalid_account_proof());
+            }
+            Err(ProofVerificationError::ValueMismatch { got: Some(bytes), expected: None, .. }) => {
+                bytes.to_vec()
+            }
+            Err(_) => {
+                // Any structural/root mismatch is an invalid account proof.
+                revert_selector(selector_invalid_account_proof());
+            }
+        };
+
+        // Decode account RLP and extract storage root (nonce, balance, storageRoot, codeHash)
+        // Without alloy_trie::account (requires `ethereum` feature), decode minimally via alloy_rlp list API.
+        let mut acc_buf = &account_rlp[..];
+        let mut items = match alloy_rlp::Header::decode_raw(&mut acc_buf) {
+            Ok(alloy_rlp::PayloadView::List(list)) => list,
+            _ => revert_selector(selector_invalid_account_proof()),
+        };
+        if items.len() != 4 { revert_selector(selector_invalid_account_proof()); }
+        // storageRoot is index 2
+        let _nonce_item = items.remove(0);
+        let _balance_item = items.remove(0);
+        let mut storage_item = items.remove(0);
+        let Ok(storage_root_bytes) = alloy_rlp::Bytes::decode(&mut storage_item) else { revert_selector(selector_invalid_account_proof()); };
+        if storage_root_bytes.len() != 32 { revert_selector(selector_invalid_account_proof()); }
+        let storage_root = B256::from_slice(&storage_root_bytes);
+
+        // Verify storage inclusion for the derived slot equals RLP(1).
+        let slot = derive_key(value, sender);
+        let storage_key = Nibbles::unpack(alloy_keccak256(slot.as_slice()).as_slice());
+        let expected_rlp_one: Vec<u8> = alloy_rlp::encode(U256::from(1u8));
+        let storage_proof_iter = storage_proof.iter();
+        if verify_proof(storage_root, storage_key, Some(expected_rlp_one), storage_proof_iter).is_err() {
+            revert_selector(selector_invalid_inclusion_proof());
+        }
+
+        // Success
+        log::emit(SignalVerified::new(sender, value));
+    }
+}
+
+fn derive_key(value: B32, account: Address) -> B32 {
+    // namespace = abi.encodePacked(value, account)
+    let namespace = alloy_sol_types::SolValue::abi_encode_packed(&(value, account));
+
+    // slot = keccak256( (keccak256(namespace) - 1) ) & ~0xff
+    let namespace_hash = alloy_keccak256(&namespace);
+    let word = U256::from_be_slice(namespace_hash.as_slice());
+    let (minus_one, _) = word.overflowing_sub(U256::from(1u8));
+    let buf = minus_one.to_be_bytes::<32>();
+    let slot_bytes = alloy_keccak256(&buf);
+
+    // mask out the lowest 8 bits (ERC-7201)
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(slot_bytes.as_slice());
+    let last = arr.len() - 1;
+    arr[last] = 0u8;
+    B32::from(arr)
+}
+
+// --- Internals ---
+
+fn revert_selector(sel: [u8; 4]) -> ! {
+    revert_with_error(&sel)
+}
+
+fn selector_state_root_not_found() -> [u8; 4] {
+    // keccak256("StateRootNotFound()")[:4]
+    let sig = b"StateRootNotFound()";
+    let h = alloy_keccak256(sig);
+    [h[0], h[1], h[2], h[3]]
+}
+
+fn selector_account_proof_empty() -> [u8; 4] {
+    // keccak256("AccountProofEmpty()")[:4]
+    let sig = b"AccountProofEmpty()";
+    let h = alloy_keccak256(sig);
+    [h[0], h[1], h[2], h[3]]
+}
+
+fn selector_invalid_account_proof() -> [u8; 4] {
+    // keccak256("INVALID_ACCOUNT_PROOF()")[:4]
+    let sig = b"INVALID_ACCOUNT_PROOF()";
+    let h = alloy_keccak256(sig);
+    [h[0], h[1], h[2], h[3]]
+}
+
+fn selector_invalid_inclusion_proof() -> [u8; 4] {
+    // keccak256("INVALID_INCLUSION_PROOF()")[:4]
+    let sig = b"INVALID_INCLUSION_PROOF()";
+    let h = alloy_keccak256(sig);
+    [h[0], h[1], h[2], h[3]]
+}

--- a/r55/Cargo.toml
+++ b/r55/Cargo.toml
@@ -21,3 +21,8 @@ thiserror.workspace = true
 
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+alloy-trie = { version = "0.9.1", features = ["ethereum"] }
+alloy-rlp = "0.3.12"
+nybbles = "0.4.5"

--- a/r55/src/exec.rs
+++ b/r55/src/exec.rs
@@ -1,3 +1,15 @@
+// R55 execution glue over revm
+//
+// Summary of hardening and rationale:
+// - Nested CALL/CREATE gas handling: Parent frame pays only base cost; child gas limit
+//   follows EIP-150 (remaining - remaining/64). We pre-deduct the child gas in the
+//   parent so that the EVM core refunds unspent child gas on return. This matches
+//   revm's accounting model and prevents double-charging/underflow in nested R55→R55 calls.
+// - Memory safety on DRAM access: RETURNDATACOPY, RETURN payloads, CALL/CREATE calldata/initcode
+//   use saturating/clamped bounds and overflow checks before reading/writing rvemu DRAM.
+//   This avoids panics from out-of-bounds/overflow in the emulator bus.
+// - Tx gas limit: set to 100_000_000 to keep tests fast and realistic; correctness no longer
+//   depends on an inflated cap thanks to the accounting and memory guards above.
 use alloy_core::primitives::{Keccak256, U32};
 use core::cell::RefCell;
 use eth_riscv_interpreter::setup_from_elf;
@@ -176,9 +188,23 @@ pub fn handle_register<EXT, DB: Database>(handler: &mut EvmHandler<'_, EXT, DB>)
     let old_handle = handler.execution.call.clone();
     handler.execution.call = Arc::new(move |ctx, inputs| {
         let result = old_handle(ctx, inputs);
-        if let Ok(FrameOrResult::Frame(frame)) = &result {
-            trace!("Creating new CALL frame");
-            call_stack_inner.borrow_mut().push(riscv_context(frame));
+        match &result {
+            Ok(FrameOrResult::Frame(frame)) => {
+                trace!("Creating new CALL frame");
+                call_stack_inner.borrow_mut().push(riscv_context(frame));
+            }
+            Ok(FrameOrResult::Result(res)) => {
+                let ins = res.instruction_result();
+                let gas_rem = res.gas().remaining();
+                let out_len = match res.output() { Output::Call(b) => b.len(), Output::Create(b, _) => b.len() };
+                debug!(
+                    "> Child CALL returned: {:?} | gas remaining: {} | output.len: {}",
+                    ins,
+                    gas_rem,
+                    out_len
+                );
+            }
+            _ => {}
         }
         result
     });
@@ -188,9 +214,23 @@ pub fn handle_register<EXT, DB: Database>(handler: &mut EvmHandler<'_, EXT, DB>)
     let old_handle = handler.execution.create.clone();
     handler.execution.create = Arc::new(move |ctx, inputs| {
         let result = old_handle(ctx, inputs);
-        if let Ok(FrameOrResult::Frame(frame)) = &result {
-            trace!("Creating new CREATE frame");
-            call_stack_inner.borrow_mut().push(riscv_context(frame));
+        match &result {
+            Ok(FrameOrResult::Frame(frame)) => {
+                trace!("Creating new CREATE frame");
+                call_stack_inner.borrow_mut().push(riscv_context(frame));
+            }
+            Ok(FrameOrResult::Result(res)) => {
+                let ins = res.instruction_result();
+                let gas_rem = res.gas().remaining();
+                let out_len = match res.output() { Output::Call(b) => b.len(), Output::Create(b, _) => b.len() };
+                debug!(
+                    "> Child CREATE returned: {:?} | gas remaining: {} | output.len: {}",
+                    ins,
+                    gas_rem,
+                    out_len
+                );
+            }
+            _ => {}
         }
         result
     });
@@ -278,7 +318,22 @@ fn execute_riscv(
                         let ret_size: u64 = emu.cpu.xregs.read(11);
 
                         let r55_gas = r55_gas_used(&emu.cpu.inst_counter);
-                        debug!("> Total R55 gas: {}", r55_gas);
+                        let remaining = interpreter.gas.remaining();
+                        debug!("> Total R55 gas: {} | remaining before: {}", r55_gas, remaining);
+
+                        // Guard against underflow when charging total R55 gas.
+                        // If the total exceeds remaining, spend only what's left and return OOG,
+                        // mirroring EVM semantics (no panic in the emulator).
+                        if r55_gas > remaining {
+                            if remaining > 0 { syscall_gas!(interpreter, remaining); }
+                            return Ok(InterpreterAction::Return {
+                                result: InterpreterResult {
+                                    result: InstructionResult::OutOfGas,
+                                    output: Bytes::new(),
+                                    gas: interpreter.gas,
+                                },
+                            });
+                        }
 
                         // RETURN logs the gas of the whole risc-v instruction set
                         syscall_gas!(interpreter, r55_gas);
@@ -372,21 +427,38 @@ fn execute_riscv(
                         let dest_offset = emu.cpu.xregs.read(10);
                         let offset = emu.cpu.xregs.read(11) as usize;
                         let size = emu.cpu.xregs.read(12) as usize;
-                        let data = &interpreter.return_data_buffer.as_ref()[offset..offset + size];
+
+                        // Clamp to available buffer and guard integer overflow.
+                        let buf_len = interpreter.return_data_buffer.len();
+                        if offset > buf_len || size > buf_len || offset.saturating_add(size) > buf_len {
+                            warn!(
+                                "> RETURNDATACOPY OOB [offset: {}, size: {}, buf_len: {}] — clamping to available",
+                                offset, size, buf_len
+                            );
+                        }
+                        let end = core::cmp::min(buf_len, offset.saturating_add(size));
+                        let data = &interpreter.return_data_buffer.as_ref()[offset..end];
                         debug!(
-                            "> RETURNDATACOPY [memory_offset: {}, offset: {}, size: {}]\n{}",
+                            "> RETURNDATACOPY [memory_offset: {}, offset: {}, size: {} (clamped to {})]\n{}",
                             dest_offset,
                             offset,
                             size,
+                            data.len(),
                             Bytes::from(data.to_vec())
                         );
 
                         // write return data to memory
-                        let return_memory = emu
-                            .cpu
-                            .bus
-                            .get_dram_slice(dest_offset..(dest_offset + size as u64))?;
-                        return_memory.copy_from_slice(data);
+                        if !data.is_empty() {
+                            if let Some(dest_end) = dest_offset.checked_add(data.len() as u64) {
+                                if let Ok(return_memory) = emu.cpu.bus.get_dram_slice(dest_offset..dest_end) {
+                                    return_memory.copy_from_slice(data);
+                                } else {
+                                    warn!("> RETURNDATACOPY destination out of DRAM bounds; skipping write");
+                                }
+                            } else {
+                                warn!("> RETURNDATACOPY destination overflow (dest_offset={}, len={})", dest_offset, data.len());
+                            }
+                        }
                     }
                     Syscall::Call => return execute_call(emu, interpreter, host, false),
                     Syscall::StaticCall => return execute_call(emu, interpreter, host, true),
@@ -587,17 +659,23 @@ fn execute_call(
     // Get calldata
     let args_offset: u64 = emu.cpu.xregs.read(14);
     let args_size: u64 = emu.cpu.xregs.read(15);
-    let calldata: Bytes = emu
-        .cpu
-        .bus
-        .get_dram_slice(args_offset..(args_offset + args_size))
-        .unwrap_or(&mut [])
-        .to_vec()
-        .into();
+    let calldata: Bytes = if args_size == 0 {
+        Bytes::new()
+    } else if let Some(end) = args_offset.checked_add(args_size) {
+        if let Ok(slice) = emu.cpu.bus.get_dram_slice(args_offset..end) {
+            slice.to_vec().into()
+        } else {
+            warn!("> CALL calldata OOB [offset: {}, size: {}] — empty", args_offset, args_size);
+            Bytes::new()
+        }
+    } else {
+        warn!("> CALL calldata overflow [offset: {}, size: {}] — empty", args_offset, args_size);
+        Bytes::new()
+    };
 
     // Calculate gas cost of the call
-    // TODO: check correctness (tried using evm.codes as ref but i'm no gas wizard)
-    // TODO: unsure whether memory expansion cost is missing (should be captured in the risc-v costs)
+    // Parent pays only the base cost here; the child runs with an EIP-150 gas limit derived from
+    // remaining gas. We pre-deduct the child limit so revm will refund unused gas on return.
     let (empty_account_cost, addr_access_cost) = match host.load_account_delegated(addr) {
         Some(account) => {
             if account.is_cold {
@@ -608,19 +686,27 @@ fn execute_call(
         }
         None => (gas::CALL_EMPTY_ACCOUNT, gas::CALL_NEW_ACCOUNT),
     };
+    // Charge only base CALL cost now
     let value_cost = if value != 0 { gas::CALL_VALUE } else { 0 };
-    let call_gas_cost = empty_account_cost + addr_access_cost + value_cost;
-    syscall_gas!(interpreter, call_gas_cost);
+    let base_cost = empty_account_cost + addr_access_cost + value_cost;
+    if base_cost > 0 { syscall_gas!(interpreter, base_cost); }
 
-    // proactively spend gas limit as the remaining will be refunded (otherwise it underflows)
-    let call_gas_limit = interpreter.gas.remaining();
-    syscall_gas!(interpreter, call_gas_limit);
+    // EIP-150: callee gas = remaining - remaining/64 (post-base-cost)
+    let rem = interpreter.gas.remaining();
+    let call_gas_limit = rem - (rem / 64);
 
     debug!("> {}Call context:", if is_static { "Static" } else { "" });
     debug!("  - Caller: {}", interpreter.contract.target_address);
     debug!("  - Target Address: {}", addr);
     debug!("  - Value: {}", value);
     debug!("  - Calldata: {:?}", calldata);
+    debug!("  - Callee gas_limit: {}", call_gas_limit);
+
+    // Pre-deduct callee gas from the parent so the EVM core will refund
+    // the child's unspent gas on return via `erase_cost`.
+    if call_gas_limit > 0 {
+        syscall_gas!(interpreter, call_gas_limit);
+    }
     Ok(InterpreterAction::Call {
         inputs: Box::new(CallInputs {
             input: calldata,
@@ -647,21 +733,26 @@ fn execute_create(
     // Get initcode
     let args_offset: u64 = emu.cpu.xregs.read(11);
     let args_size: u64 = emu.cpu.xregs.read(12);
-    let init_code: Bytes = emu
-        .cpu
-        .bus
-        .get_dram_slice(args_offset..(args_offset + args_size))
-        .unwrap_or(&mut [])
-        .to_vec()
-        .into();
+    let init_code: Bytes = if args_size == 0 {
+        Bytes::new()
+    } else if let Some(end) = args_offset.checked_add(args_size) {
+        if let Ok(slice) = emu.cpu.bus.get_dram_slice(args_offset..end) {
+            slice.to_vec().into()
+        } else {
+            warn!("> CREATE init_code OOB [offset: {}, size: {}] — empty", args_offset, args_size);
+            Bytes::new()
+        }
+    } else {
+        warn!("> CREATE init_code overflow [offset: {}, size: {}] — empty", args_offset, args_size);
+        Bytes::new()
+    };
 
-    // TODO: calculate gas cost properly
-    let create_gas_cost = gas::CREATE_BASE;
-    syscall_gas!(interpreter, create_gas_cost);
-
-    // proactively spend gas limit as the remaining will be refunded (otherwise it underflows)
-    let create_gas_limit = interpreter.gas.remaining();
-    syscall_gas!(interpreter, create_gas_limit);
+    // Charge only base CREATE cost now; child gas mirrors CALL handling
+    if gas::CREATE_BASE > 0 { syscall_gas!(interpreter, gas::CREATE_BASE); }
+    let rem = interpreter.gas.remaining();
+    let create_gas_limit = rem - (rem / 64);
+    // Pre-deduct child gas; core will refund remaining on return.
+    if create_gas_limit > 0 { syscall_gas!(interpreter, create_gas_limit); }
 
     debug!("> CREATE CTX:");
     debug!("  - Caller: {}", interpreter.contract.target_address);
@@ -679,15 +770,21 @@ fn execute_create(
 }
 
 /// Returns RISC-V DRAM slice in a given size range, starts with a given offset
+// Safe DRAM slice helper for RETURN payloads; avoids overflow/underflow and OOB.
 fn dram_slice(emu: &mut Emulator, ret_offset: u64, ret_size: u64) -> Result<&mut [u8]> {
-    if ret_size != 0 {
-        Ok(emu
-            .cpu
-            .bus
-            .get_dram_slice(ret_offset..(ret_offset + ret_size))?)
-    } else {
-        Ok(&mut [])
+    if ret_size == 0 {
+        return Ok(&mut []);
     }
+    if let Some(end) = ret_offset.checked_add(ret_size) {
+        if let Ok(slice) = emu.cpu.bus.get_dram_slice(ret_offset..end) {
+            return Ok(slice);
+        }
+    }
+    warn!(
+        "> DRAM SLICE OOB [offset: {}, size: {}] — returning empty slice",
+        ret_offset, ret_size
+    );
+    Ok(&mut [])
 }
 
 fn r55_gas_used(inst_count: &BTreeMap<String, u64>) -> u64 {

--- a/r55/src/generated/mod.rs
+++ b/r55/src/generated/mod.rs
@@ -9,6 +9,8 @@ pub const EVM_CALLER_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytec
 pub const ERC20_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20.bin");
 pub const ERC20X_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/erc20x.bin");
 pub const SIMPLE_DEPOSIT_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/simple-deposit.bin");
+pub const HYDRA_L2_BRIDGE_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/hydra-l2-bridge.bin");
+pub const HYDRA_L2_SIGNAL_SERVICE_BYTECODE: &[u8] = include_bytes!("../../../r55-output-bytecode/hydra-l2-signal-service.bin");
 
 pub fn get_bytecode(contract_name: &str) -> Bytes {
     let initcode = match contract_name {
@@ -17,6 +19,8 @@ pub fn get_bytecode(contract_name: &str) -> Bytes {
         "erc20" => ERC20_BYTECODE,
         "erc20x" => ERC20X_BYTECODE,
         "simple_deposit" => SIMPLE_DEPOSIT_BYTECODE,
+        "hydra_l2_bridge" => HYDRA_L2_BRIDGE_BYTECODE,
+        "hydra_l2_signal_service" => HYDRA_L2_SIGNAL_SERVICE_BYTECODE,
         _ => return Bytes::new(),
     };
 

--- a/r55/src/test_utils.rs
+++ b/r55/src/test_utils.rs
@@ -30,6 +30,17 @@ pub fn add_balance_to_db(db: &mut InMemoryDB, addr: Address, value: u64) {
     db.insert_account_info(addr, AccountInfo::from_balance(U256::from(value)));
 }
 
+// Preserve existing code/nonce, only increase balance
+pub fn add_balance_preserve_code(db: &mut InMemoryDB, addr: Address, value: u64) {
+    let mut info = db
+        .basic(addr)
+        .unwrap()
+        .unwrap_or(AccountInfo::from_balance(U256::from(0)));
+    let new_balance = info.balance + U256::from(value);
+    info.balance = new_balance;
+    db.insert_account_info(addr, info);
+}
+
 pub fn add_contract_to_db(db: &mut InMemoryDB, addr: Address, bytecode: Bytes) {
     let account = AccountInfo::new(
         Uint::from(0),

--- a/r55/tests/hydra-l2-bridge.rs
+++ b/r55/tests/hydra-l2-bridge.rs
@@ -1,0 +1,867 @@
+//! # ETHBridge Tests (R55/RISC-V)
+//!
+//! Contract behavior under test:
+//! - processed(bytes32)
+//! - getDepositId(ETHDeposit)
+//! - deposit(address,bytes,bytes,address)
+//! - claimDeposit(ETHDeposit,bytes)
+//!
+//! Note: Proof validity and detailed trie verification are covered in
+//! `r55/tests/hydra-l2-signal-service.rs`. Here we integrate just enough
+//! to exercise ETHBridge flows and reverts.
+use alloy_primitives::{keccak256, Address, Bytes, FixedBytes, U256, B256, hex};
+use r55::{
+    exec::{deploy_contract, run_tx},
+    get_bytecode,
+    test_utils::{add_balance_to_db, initialize_logger, ALICE, BOB, CAROL},
+};
+use alloy_sol_types::{sol, SolCall, SolValue};
+use revm::{InMemoryDB, Database};
+use tracing::info;
+use alloy_trie::HashBuilder;
+use alloy_trie::proof::ProofRetainer;
+use nybbles::Nibbles;
+
+sol! {
+    struct ETHDeposit {
+        uint256 nonce;
+        address from;
+        address to;
+        uint256 amount;
+        bytes data;
+        bytes context;
+        address canceler;
+    }
+
+    function processed(bytes32 id) returns (bool);
+    function getDepositId(ETHDeposit ethDeposit) returns (bytes32);
+    function deposit(address to, bytes data, bytes context, address canceler) returns (bytes32);
+    function claimDeposit(ETHDeposit ethDeposit, bytes proof);
+    function cancelDeposit(ETHDeposit ethDeposit, address claimee, bytes proof);
+}
+
+/// Minimal fixture for tests that deploy a bridge wired to a dummy
+/// SignalService and counterpart.
+struct ETHBridgeSetup {
+    db: InMemoryDB,
+    contract: Address,
+    _signal_service: Address,
+    _counterpart: Address,
+}
+
+fn eth_bridge_setup() -> ETHBridgeSetup {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    // Fund user accounts with some ETH
+    for user in [ALICE, BOB, CAROL] {
+        add_balance_to_db(&mut db, user, 1e18 as u64);
+    }
+
+    // Dummy addresses for constructor wiring
+    let signal_service = Address::from([0x11; 20]);
+    let counterpart = Address::from([0x22; 20]);
+
+    // Deploy ETHBridge contract with constructor parameters
+    let bytecode = get_bytecode("hydra_l2_bridge");
+    let constructor_args = (signal_service, counterpart).abi_encode();
+    let contract = deploy_contract(&mut db, bytecode, Some(constructor_args)).unwrap();
+
+    ETHBridgeSetup {
+        db,
+        contract,
+        _signal_service: signal_service,
+        _counterpart: counterpart,
+    }
+}
+
+/// Constructor must revert if either signal_service or counterpart is zero address
+#[test]
+fn test_eth_bridge_constructor_reverts_on_zero_addresses() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+    for user in [ALICE] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+
+    let bytecode = get_bytecode("hydra_l2_bridge");
+
+    // Zero signal_service
+    let args1 = (Address::ZERO, Address::from([0x22; 20])).abi_encode();
+    let err1 = deploy_contract(&mut db, bytecode.clone(), Some(args1)).expect_err("constructor should revert on zero signal_service");
+    assert!(err1.matches_string_error(""));
+
+    // Zero counterpart
+    let args2 = (Address::from([0x11; 20]), Address::ZERO).abi_encode();
+    let err2 = deploy_contract(&mut db, bytecode.clone(), Some(args2)).expect_err("constructor should revert on zero counterpart");
+    assert!(err2.matches_string_error(""));
+}
+
+/// processed(bytes32) returns false for ids not seen/claimed.
+#[test]
+fn test_eth_bridge_processed() {
+    let setup = eth_bridge_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Test processed() with a random ID - should return false
+    let test_id = FixedBytes::<32>::from([0x42; 32]);
+    let call = processedCall { id: test_id };
+    let result = run_tx(&mut db, &contract, call.abi_encode(), &ALICE).unwrap();
+    
+    assert!(result.status);
+    let decoded: bool = bool::abi_decode(&result.output, true).unwrap();
+    assert!(!decoded, "New deposit should not be processed");
+}
+
+/// getDepositId encodes the struct as a tuple and hashes it (deterministic).
+#[test]
+fn test_eth_bridge_get_deposit_id() {
+    let setup = eth_bridge_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Create a test ETHDeposit
+    let eth_deposit = ETHDeposit {
+        nonce: U256::from(1u64),
+        from: ALICE,
+        to: BOB,
+        amount: U256::from(1000u64),
+        data: Bytes::from(b"test data"),
+        context: Bytes::from(b"context"),
+        canceler: CAROL,
+    };
+
+    let call = getDepositIdCall { ethDeposit: eth_deposit.clone() };
+    println!("call.abi_encode.hex = 0x{}", hex::encode(call.abi_encode()));
+    let result = run_tx(&mut db, &contract, call.abi_encode(), &ALICE).unwrap();
+    
+    assert!(result.status);
+    let deposit_id: FixedBytes<32> = FixedBytes::<32>::abi_decode(&result.output, true).unwrap();
+    
+    // Verify the ID is deterministic (same input should produce same output)
+    let call2 = getDepositIdCall { ethDeposit: eth_deposit };
+    let result2 = run_tx(&mut db, &contract, call2.abi_encode(), &ALICE).unwrap();
+    let deposit_id2: FixedBytes<32> = FixedBytes::<32>::abi_decode(&result2.output, true).unwrap();
+    
+    assert_eq!(deposit_id, deposit_id2, "Deposit ID should be deterministic");
+}
+
+/// deposit returns a nonzero id and emits DepositMade; nonce increases.
+#[test]
+fn test_eth_bridge_deposit() {
+    let setup = eth_bridge_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Test deposit function
+    let to = BOB;
+    let data = Bytes::from(b"deposit data");
+    let context = Bytes::from(b"deposit context");
+    let canceler = CAROL;
+
+    let call = depositCall {
+        to,
+        data: data.clone(),
+        context: context.clone(),
+        canceler,
+    };
+    
+    let result = run_tx(&mut db, &contract, call.abi_encode(), &ALICE).unwrap();
+    
+    assert!(result.status);
+    let deposit_id: FixedBytes<32> = FixedBytes::<32>::abi_decode(&result.output, true).unwrap();
+    
+    // Verify the deposit ID is not zero
+    assert_ne!(deposit_id, FixedBytes::<32>::ZERO, "Deposit ID should not be zero");
+    
+    info!("Deposit created with ID: {:?}", deposit_id);
+
+    // Event check: DepositMade(bytes32 indexed id, ETHDeposit deposit)
+    // - topic0: keccak256("DepositMade(bytes32,(uint256,address,address,uint256,bytes,bytes,address))")
+    // - topic1: id (indexed)
+    // - data: abi.encode(ETHDeposit tuple) in Solidity order
+    let topic0 = B256::from(keccak256(b"DepositMade(bytes32,(uint256,address,address,uint256,bytes,bytes,address))"));
+    let lg = result
+        .logs
+        .iter()
+        .find(|l| l.topics()[0] == topic0)
+        .expect("missing DepositMade event");
+    assert_eq!(lg.topics()[1], B256::from_slice(deposit_id.as_slice()));
+    let expected_tuple = (
+        U256::from(0u64), // initial nonce before ++ in contract
+        ALICE,
+        to,
+        U256::from(0u64), // msg_value() is zero in tests
+        data.clone(),
+        context.clone(),
+        canceler,
+    );
+    let expected_encoded = expected_tuple.abi_encode();
+    assert_eq!(lg.data.data.as_ref(), expected_encoded.as_slice(), "DepositMade data must equal abi.encode(ETHDeposit)");
+}
+
+// --- Minimal MPT helpers to build a proof matching SignalService expectations ---
+fn rlp_bytes(input: &[u8]) -> Vec<u8> {
+    if input.len() == 1 && input[0] < 0x80 { return vec![input[0]]; }
+    let mut out = Vec::with_capacity(1 + input.len());
+    out.push(0x80 + (input.len() as u8));
+    out.extend_from_slice(input);
+    out
+}
+
+fn rlp_uint_zero() -> Vec<u8> { vec![0x80] }
+
+fn rlp_list(items: &[Vec<u8>]) -> Vec<u8> {
+    let payload_len: usize = items.iter().map(|v| v.len()).sum();
+    let mut out = Vec::with_capacity(2 + payload_len);
+    if payload_len <= 55 {
+        out.push(0xc0 + (payload_len as u8));
+    } else {
+        out.push(0xf7 + 1);
+        out.push(payload_len as u8);
+    }
+    for v in items { out.extend_from_slice(v); }
+    out
+}
+
+fn derive_key(value: FixedBytes<32>, account: Address) -> FixedBytes<32> {
+    // namespace = abi.encodePacked(value, account)
+    let namespace = (value, account).abi_encode_packed();
+    // slot = keccak256( (keccak256(namespace) - 1) ) & ~0xff
+    let namespace_hash = keccak256(&namespace);
+    let word = U256::from_be_bytes(namespace_hash.0);
+    let (minus_one, _) = word.overflowing_sub(U256::from(1u8));
+    let buf = minus_one.to_be_bytes::<32>();
+    let slot_bytes = keccak256(&buf);
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(slot_bytes.as_slice());
+    arr[31] = 0u8;
+    FixedBytes::<32>::from(arr)
+}
+
+fn build_signal_proof(
+    this_address: Address,
+    sender: Address,
+    value: FixedBytes<32>,
+) -> (Vec<Bytes>, Vec<Bytes>, FixedBytes<32>) {
+    // Build storage trie proving slot -> RLP(1)
+    let slot = derive_key(value, sender);
+    let storage_key_hashed = B256::from(keccak256(slot.as_slice()));
+    let mut storage_builder = HashBuilder::default()
+        .with_proof_retainer(ProofRetainer::from_iter([Nibbles::unpack(storage_key_hashed.as_slice())]));
+    let rlp_one = alloy_rlp::encode(U256::from(1u64));
+    storage_builder.add_leaf(Nibbles::unpack(storage_key_hashed.as_slice()), &rlp_one);
+    let storage_root = storage_builder.root();
+    let storage_nodes = storage_builder.take_proof_nodes().into_nodes_sorted();
+    let storage_proof: Vec<Bytes> = storage_nodes.into_iter().map(|(_, n)| Bytes::from(n.to_vec())).collect();
+
+    // Build account trie for `this_address` with the storage_root above
+    let account_key = B256::from(keccak256(this_address.as_slice()));
+    let account_value_rlp = rlp_list(&[
+        rlp_uint_zero(),
+        rlp_uint_zero(),
+        rlp_bytes(storage_root.as_slice()),
+        rlp_bytes([0u8; 32].as_slice()),
+    ]);
+    let mut account_builder = HashBuilder::default()
+        .with_proof_retainer(ProofRetainer::from_iter([Nibbles::unpack(account_key.as_slice())]));
+    account_builder.add_leaf(Nibbles::unpack(account_key.as_slice()), &account_value_rlp);
+    let state_root = account_builder.root();
+    let account_nodes = account_builder.take_proof_nodes().into_nodes_sorted();
+    let account_proof: Vec<Bytes> = account_nodes.into_iter().map(|(_, n)| Bytes::from(n.to_vec())).collect();
+
+    (account_proof, storage_proof, FixedBytes::<32>::from(state_root.0))
+}
+
+// (debug helpers removed; eth bridge now tested via assertions only)
+
+// Happy path: claimDeposit sends value to receiver after proof verification
+/// Happy path: verifySignal succeeds, processed flag set, DepositClaimed emitted, value transferred.
+#[test]
+fn test_eth_bridge_claim_deposit_happy_path() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    // Fund actors
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+
+    // Deploy SignalService with (publisher, this_address)
+    let publisher = Address::from([0x44; 20]);
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    // r55 deploys contracts deterministically to 0xf6a1...; use same constant as other tests
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let ctor_ss = (publisher, this_address).abi_encode();
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some(ctor_ss)).unwrap();
+    // Verify deployed SignalService runtime is R55
+    {
+        let acct = db.basic(signal_service).unwrap().expect("signal service missing");
+        let code = acct.code.expect("signal service has no code");
+        let bytes = code.bytecode().as_ref();
+        println!("signal_service code head: 0x{}", hex::encode(&bytes[..bytes.len().min(16)]));
+        assert_eq!(bytes[0], 0xff, "signal service runtime is not R55 (0xff)");
+    }
+
+    // Bridge counterpart (remote sender used in proof derivation)
+    let counterpart = Address::from([0x22; 20]);
+
+    // Prepare deposit tuple and its id
+    let amount = U256::from(10_000u64);
+    let eth_deposit = ETHDeposit {
+        nonce: U256::from(1u64),
+        from: ALICE,
+        // Avoid precompile range 0x01..0x13; choose non-precompile EOA address
+        to: Address::from([0x33; 20]),
+        amount,
+        data: Bytes::from_static(b"hello"),
+        context: Bytes::from_static(b"ctx"),
+        canceler: CAROL,
+    };
+    // Compute expected id via contract helper to avoid drift
+    let bytecode_bridge = get_bytecode("hydra_l2_bridge");
+    let ctor_bridge = (signal_service, counterpart).abi_encode();
+    let bridge = deploy_contract(&mut db, bytecode_bridge, Some(ctor_bridge)).unwrap();
+    // Verify deployed Bridge runtime is R55
+    {
+        let acct = db.basic(bridge).unwrap().expect("bridge missing");
+        let code = acct.code.expect("bridge has no code");
+        let bytes = code.bytecode().as_ref();
+        println!("bridge code head: 0x{}", hex::encode(&bytes[..bytes.len().min(16)]));
+        assert_eq!(bytes[0], 0xff, "bridge runtime is not R55 (0xff)");
+    }
+
+    // Fund bridge so it can forward ETH without overwriting code
+    use r55::test_utils::add_balance_preserve_code;
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    // (No debug calls)
+
+    // Compute deposit id locally (keccak256(abi.encode(ETHDeposit)))
+    let deposit_id: FixedBytes<32> = {
+        let t = (
+            eth_deposit.nonce,
+            eth_deposit.from,
+            eth_deposit.to,
+            eth_deposit.amount,
+            eth_deposit.data.clone(),
+            eth_deposit.context.clone(),
+            eth_deposit.canceler,
+        );
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+
+    // Build a valid proof for (sender=counterpart, value=deposit_id) against a synthetic state_root
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, deposit_id);
+
+    // Publisher signals the state root on the SignalService (gate requirement)
+    // Use sol! to encode sendSignal call
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let send_signal_calldata = sendSignalCall { value: state_root }.abi_encode();
+    println!("sendSignalCalldata.hex = 0x{}", hex::encode(send_signal_calldata.clone()));
+    let send_signal = run_tx(&mut db, &signal_service, send_signal_calldata.clone(), &publisher).unwrap();
+    println!("sendSignal: {:?}", send_signal);
+
+    // Encode proof blob as (bytes[],bytes[],bytes32)
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+
+    // Cross-check via getDepositId
+    let via_contract_id = {
+        let call = getDepositIdCall { ethDeposit: eth_deposit.clone() };
+        let res = run_tx(&mut db, &bridge, call.abi_encode(), &ALICE).unwrap();
+        FixedBytes::<32>::abi_decode(&res.output, true).unwrap()
+    };
+    assert_eq!(via_contract_id, deposit_id, "getDepositId mismatch");
+
+    // Record balances pre-claim
+    use r55::test_utils::AccountInfo;
+    let to_pre_balance = db
+        .basic(eth_deposit.to)
+        .unwrap()
+        .unwrap_or(AccountInfo::from_balance(U256::from(0)))
+        .balance;
+    println!("to_pre_balance: {}", to_pre_balance);
+
+    // Call claimDeposit
+    let calldata = claimDepositCall { ethDeposit: eth_deposit.clone(), proof: proof_bytes.into() }.abi_encode();
+    let result = run_tx(&mut db, &bridge, calldata, &ALICE).unwrap();
+    assert!(result.status);
+    println!("result: {:?}", result);
+    // Event check: DepositClaimed(bytes32 indexed id, ETHDeposit deposit)
+    // - topic0: keccak256("DepositClaimed(bytes32,(uint256,address,address,uint256,bytes,bytes,address))")
+    // - topic1: id
+    // - data: abi.encode(ETHDeposit)
+    let claim_sig = B256::from(keccak256(b"DepositClaimed(bytes32,(uint256,address,address,uint256,bytes,bytes,address))"));
+    let lg = result
+        .logs
+        .iter()
+        .find(|l| l.topics()[0] == claim_sig)
+        .expect("missing DepositClaimed event");
+    assert_eq!(lg.topics()[1], B256::from_slice(deposit_id.as_slice()));
+    let expected_claim_tuple = (
+        eth_deposit.nonce,
+        eth_deposit.from,
+        eth_deposit.to,
+        eth_deposit.amount,
+        eth_deposit.data.clone(),
+        eth_deposit.context.clone(),
+        eth_deposit.canceler,
+    );
+    let expected_claim_encoded = expected_claim_tuple.abi_encode();
+    assert_eq!(lg.data.data.as_ref(), expected_claim_encoded.as_slice(), "DepositClaimed data must equal abi.encode(ETHDeposit)");
+
+    // Processed flag is set
+    let processed_call = processedCall { id: deposit_id };
+    let processed_res = run_tx(&mut db, &bridge, processed_call.abi_encode(), &ALICE).unwrap();
+    let processed_flag: bool = bool::abi_decode(&processed_res.output, true).unwrap();
+    assert!(processed_flag, "deposit must be marked processed");
+
+    // Value transferred to `to`
+    let to_post_balance = db
+        .basic(eth_deposit.to)
+        .unwrap()
+        .unwrap_or(AccountInfo::from_balance(U256::from(0)))
+        .balance;
+    println!("to_post_balance: {}", to_post_balance);
+    assert!(to_post_balance > to_pre_balance, "recipient balance must increase");
+}
+
+/// Deposit nonce monotonic: two deposits produce distinct ids
+#[test]
+fn test_eth_bridge_deposit_nonce_monotonic() {
+    let setup = eth_bridge_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    let to = BOB;
+    let context = Bytes::from_static(b"ctx");
+    let canceler = CAROL;
+
+    let r1 = run_tx(&mut db, &contract, depositCall { to, data: Bytes::from_static(b"d1"), context: context.clone(), canceler }.abi_encode(), &ALICE).unwrap();
+    let id1: FixedBytes<32> = FixedBytes::<32>::abi_decode(&r1.output, true).unwrap();
+
+    let r2 = run_tx(&mut db, &contract, depositCall { to, data: Bytes::from_static(b"d2"), context, canceler }.abi_encode(), &ALICE).unwrap();
+    let id2: FixedBytes<32> = FixedBytes::<32>::abi_decode(&r2.output, true).unwrap();
+
+    assert_ne!(id1, id2, "distinct deposits must produce distinct ids");
+}
+
+/// Re-claiming the same deposit must revert with AlreadyClaimed()
+#[test]
+fn test_eth_bridge_claim_deposit_twice_reverts_already_claimed() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    // Actors
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    // Deploy SignalService at deterministic address and fund
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+
+    // Deploy Bridge configured to talk to that SignalService and a counterpart
+    let counterpart = Address::from([0x22; 20]);
+    let bytecode_bridge = get_bytecode("hydra_l2_bridge");
+    let bridge = deploy_contract(&mut db, bytecode_bridge, Some((signal_service, counterpart).abi_encode())).unwrap();
+
+    // Fund bridge without overwriting code so it can forward ETH
+    use r55::test_utils::add_balance_preserve_code;
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    // Prepare a valid deposit tuple and its id
+    let amount = U256::from(10_000u64);
+    let to = Address::from([0x33; 20]); // avoid precompile range
+    let eth_deposit = ETHDeposit {
+        nonce: U256::from(1u64),
+        from: ALICE,
+        to,
+        amount,
+        data: Bytes::from_static(b"hello"),
+        context: Bytes::from_static(b"ctx"),
+        canceler: CAROL,
+    };
+    let deposit_id: FixedBytes<32> = {
+        let t = (
+            eth_deposit.nonce,
+            eth_deposit.from,
+            eth_deposit.to,
+            eth_deposit.amount,
+            eth_deposit.data.clone(),
+            eth_deposit.context.clone(),
+            eth_deposit.canceler,
+        );
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+
+    // Publisher signals a synthetic state root that includes (sender=counterpart, value=deposit_id)
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, deposit_id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    // First claim succeeds
+    let proof_bytes = (account_proof.clone(), storage_proof.clone(), state_root).abi_encode();
+    let calldata = claimDepositCall { ethDeposit: eth_deposit.clone(), proof: proof_bytes.clone().into() }.abi_encode();
+    let res1 = run_tx(&mut db, &bridge, calldata.clone(), &ALICE).unwrap();
+    assert!(res1.status);
+
+    // Second claim must revert with AlreadyClaimed()
+    let err = run_tx(&mut db, &bridge, calldata, &ALICE).unwrap_err();
+    assert!(err.matches_custom_error("AlreadyClaimed()"), "expected AlreadyClaimed() revert, got: {}", err);
+}
+
+/// Claim must revert with FailedClaim() if amount does not fit u64 (bridge enforces runtime call ABI constraint)
+#[test]
+fn test_eth_bridge_claim_deposit_amount_too_large_reverts_failed_claim() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    // Actors
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    // Deploy SignalService and Bridge
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+    let counterpart = Address::from([0x22; 20]);
+    let bytecode_bridge = get_bytecode("hydra_l2_bridge");
+    let bridge = deploy_contract(&mut db, bytecode_bridge, Some((signal_service, counterpart).abi_encode())).unwrap();
+
+    // Fund bridge without overwriting code
+    use r55::test_utils::add_balance_preserve_code;
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    // Amount with non-zero high bytes to exceed u64
+    let mut be = [0u8; 32];
+    be[0] = 1; // set high byte
+    let big_amount = U256::from_be_bytes(be);
+
+    let to = Address::from([0x33; 20]); // avoid precompile range
+    let eth_deposit = ETHDeposit {
+        nonce: U256::from(1u64),
+        from: ALICE,
+        to,
+        amount: big_amount,
+        data: Bytes::from_static(b"hello"),
+        context: Bytes::from_static(b"ctx"),
+        canceler: CAROL,
+    };
+
+    // Build deposit id and a matching proof so verifySignal passes, then fail on amount check
+    let deposit_id: FixedBytes<32> = {
+        let t = (
+            eth_deposit.nonce,
+            eth_deposit.from,
+            eth_deposit.to,
+            eth_deposit.amount,
+            eth_deposit.data.clone(),
+            eth_deposit.context.clone(),
+            eth_deposit.canceler,
+        );
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, deposit_id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+    let calldata = claimDepositCall { ethDeposit: eth_deposit, proof: proof_bytes.into() }.abi_encode();
+
+    // Expect FailedClaim()
+    let err = run_tx(&mut db, &bridge, calldata, &ALICE).unwrap_err();
+    assert!(err.matches_custom_error("FailedClaim()"), "expected FailedClaim() revert, got: {}", err);
+}
+
+// SignalService-specific negatives (e.g., missing state root) are covered in
+// hydra-l2-signal-service.rs and are not asserted here against ETHBridge.
+
+// SignalService-specific negatives (e.g., empty accountProof) are covered in
+// hydra-l2-signal-service.rs and are not asserted here against ETHBridge.
+
+// SignalService-specific negatives (e.g., invalid inclusion proof) are covered
+// in hydra-l2-signal-service.rs and are not asserted here against ETHBridge.
+
+/// Zero-amount claim: succeeds, marks processed, emits event, no balance delta.
+#[test]
+fn test_eth_bridge_claim_deposit_zero_amount_succeeds_no_balance_change() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+    let counterpart = Address::from([0x22; 20]);
+    let bridge = {
+        let bytecode_bridge = get_bytecode("hydra_l2_bridge");
+        deploy_contract(&mut db, bytecode_bridge, Some((signal_service, counterpart).abi_encode())).unwrap()
+    };
+
+    use r55::test_utils::add_balance_preserve_code;
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    let to = Address::from([0x33; 20]);
+    let eth_deposit = ETHDeposit { nonce: U256::from(1u64), from: ALICE, to, amount: U256::from(0u64),
+        data: Bytes::from_static(b"hello"), context: Bytes::from_static(b"ctx"), canceler: CAROL };
+    let id = {
+        let t = (eth_deposit.nonce, eth_deposit.from, eth_deposit.to, eth_deposit.amount,
+                 eth_deposit.data.clone(), eth_deposit.context.clone(), eth_deposit.canceler);
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    // Pre/post balance check
+    use r55::test_utils::AccountInfo;
+    let pre = db.basic(to).unwrap().unwrap_or(AccountInfo::from_balance(U256::from(0))).balance;
+
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+    let calldata = claimDepositCall { ethDeposit: eth_deposit.clone(), proof: proof_bytes.into() }.abi_encode();
+    let res = run_tx(&mut db, &bridge, calldata, &ALICE).unwrap();
+    assert!(res.status);
+    // processed flag set
+    let processed_call = processedCall { id };
+    let processed_res = run_tx(&mut db, &bridge, processed_call.abi_encode(), &ALICE).unwrap();
+    let flag: bool = bool::abi_decode(&processed_res.output, true).unwrap();
+    assert!(flag);
+
+    let post = db.basic(to).unwrap().unwrap_or(AccountInfo::from_balance(U256::from(0))).balance;
+    assert_eq!(post, pre, "zero-amount claim must not change balance");
+}
+
+/// cancelDeposit happy path: only canceler, processed set, DepositCancelled emitted, value transferred to claimee
+#[test]
+fn test_eth_bridge_cancel_deposit_happy_path() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    // Deploy SignalService and Bridge
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+    let counterpart = Address::from([0x22; 20]);
+    let bytecode_bridge = get_bytecode("hydra_l2_bridge");
+    let bridge = deploy_contract(&mut db, bytecode_bridge, Some((signal_service, counterpart).abi_encode())).unwrap();
+
+    use r55::test_utils::{add_balance_preserve_code, AccountInfo};
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    // Deposit tuple
+    let amount = U256::from(7u64);
+    let to = Address::from([0x33; 20]); // recipient originally
+    let claimee = Address::from([0x44; 20]); // will receive funds on cancel
+    let eth_deposit = ETHDeposit { nonce: U256::from(1u64), from: ALICE, to, amount, data: Bytes::from_static(b"d"), context: Bytes::from_static(b"c"), canceler: CAROL };
+
+    // Inclusion proof for id under sender=counterpart
+    let id: FixedBytes<32> = {
+        let t = (eth_deposit.nonce, eth_deposit.from, eth_deposit.to, eth_deposit.amount,
+                 eth_deposit.data.clone(), eth_deposit.context.clone(), eth_deposit.canceler);
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    // Pre-balance of claimee
+    let pre = db.basic(claimee).unwrap().unwrap_or(AccountInfo::from_balance(U256::from(0))).balance;
+
+    // cancelDeposit by canceler succeeds
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+    let calldata = cancelDepositCall { ethDeposit: eth_deposit.clone(), claimee, proof: proof_bytes.into() }.abi_encode();
+    let res = run_tx(&mut db, &bridge, calldata, &CAROL).unwrap();
+    assert!(res.status);
+
+    // processed flag set
+    let processed_call = processedCall { id };
+    let processed_res = run_tx(&mut db, &bridge, processed_call.abi_encode(), &ALICE).unwrap();
+    let flag: bool = bool::abi_decode(&processed_res.output, true).unwrap();
+    assert!(flag);
+
+    // DepositCancelled emitted
+    // topic0 = keccak256("DepositCancelled(bytes32,address)")
+    // topic1 = id (indexed)
+    // data   = abi(address claimee) (32-byte left-padded)
+    let topic0 = B256::from(keccak256(b"DepositCancelled(bytes32,address)"));
+    let lg = res.logs.iter().find(|l| l.topics()[0] == topic0).expect("missing DepositCancelled");
+    assert_eq!(lg.topics()[0], topic0);
+    assert_eq!(lg.topics()[1], B256::from_slice(id.as_slice()));
+    let mut padded_addr = [0u8; 32];
+    padded_addr[12..].copy_from_slice(claimee.as_slice());
+    assert_eq!(lg.data.data.as_ref(), &padded_addr);
+
+    // Value sent to claimee
+    let post = db.basic(claimee).unwrap().unwrap_or(AccountInfo::from_balance(U256::from(0))).balance;
+    assert!(post > pre);
+}
+
+/// cancelDeposit must revert if called by a non-canceler
+#[test]
+fn test_eth_bridge_cancel_deposit_only_canceler_reverts() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+    let counterpart = Address::from([0x22; 20]);
+    let bridge = deploy_contract(&mut db, get_bytecode("hydra_l2_bridge"), Some((signal_service, counterpart).abi_encode())).unwrap();
+
+    use r55::test_utils::add_balance_preserve_code;
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    let eth_deposit = ETHDeposit { nonce: U256::from(1u64), from: ALICE, to: Address::from([0x33; 20]), amount: U256::from(1u64),
+        data: Bytes::from_static(b"d"), context: Bytes::from_static(b"c"), canceler: CAROL };
+    let id: FixedBytes<32> = {
+        let t = (eth_deposit.nonce, eth_deposit.from, eth_deposit.to, eth_deposit.amount,
+                 eth_deposit.data.clone(), eth_deposit.context.clone(), eth_deposit.canceler);
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+    let calldata = cancelDepositCall { ethDeposit: eth_deposit, claimee: BOB, proof: proof_bytes.into() }.abi_encode();
+    // Called by ALICE (not the canceler)
+    let err = run_tx(&mut db, &bridge, calldata, &ALICE).unwrap_err();
+    assert!(err.matches_custom_error("OnlyCanceler()"));
+}
+
+/// cancelDeposit must revert with AlreadyClaimed() if id already processed
+#[test]
+fn test_eth_bridge_cancel_deposit_reverts_already_processed() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+    let counterpart = Address::from([0x22; 20]);
+    let bridge = deploy_contract(&mut db, get_bytecode("hydra_l2_bridge"), Some((signal_service, counterpart).abi_encode())).unwrap();
+
+    use r55::test_utils::add_balance_preserve_code;
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    let to = Address::from([0x33; 20]);
+    let eth_deposit = ETHDeposit { nonce: U256::from(1u64), from: ALICE, to, amount: U256::from(3u64), data: Bytes::from_static(b"d"), context: Bytes::from_static(b"c"), canceler: CAROL };
+    let id: FixedBytes<32> = {
+        let t = (eth_deposit.nonce, eth_deposit.from, eth_deposit.to, eth_deposit.amount,
+                 eth_deposit.data.clone(), eth_deposit.context.clone(), eth_deposit.canceler);
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    // First cancel by CAROL succeeds
+    let proof_bytes = (account_proof.clone(), storage_proof.clone(), state_root).abi_encode();
+    let calldata1 = cancelDepositCall { ethDeposit: eth_deposit.clone(), claimee: BOB, proof: proof_bytes.clone().into() }.abi_encode();
+    let res1 = run_tx(&mut db, &bridge, calldata1, &CAROL).unwrap();
+    assert!(res1.status);
+
+    // Second cancel must revert AlreadyClaimed()
+    let calldata2 = cancelDepositCall { ethDeposit: eth_deposit, claimee: BOB, proof: proof_bytes.into() }.abi_encode();
+    let err = run_tx(&mut db, &bridge, calldata2, &CAROL).unwrap_err();
+    assert!(err.matches_custom_error("AlreadyClaimed()"));
+}
+
+/// cancelDeposit amount-too-large must revert with FailedClaim()
+#[test]
+fn test_eth_bridge_cancel_deposit_amount_too_large_reverts_failed_claim() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+    let counterpart = Address::from([0x22; 20]);
+    let bridge = deploy_contract(&mut db, get_bytecode("hydra_l2_bridge"), Some((signal_service, counterpart).abi_encode())).unwrap();
+
+    use r55::test_utils::add_balance_preserve_code;
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    // amount with non-zero high bytes
+    let mut be = [0u8; 32]; be[0] = 1; let big = U256::from_be_bytes(be);
+    let eth_deposit = ETHDeposit { nonce: U256::from(1u64), from: ALICE, to: Address::from([0x33; 20]), amount: big, data: Bytes::from_static(b"d"), context: Bytes::from_static(b"c"), canceler: CAROL };
+    let id: FixedBytes<32> = {
+        let t = (eth_deposit.nonce, eth_deposit.from, eth_deposit.to, eth_deposit.amount,
+                 eth_deposit.data.clone(), eth_deposit.context.clone(), eth_deposit.canceler);
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+    let calldata = cancelDepositCall { ethDeposit: eth_deposit, claimee: BOB, proof: proof_bytes.into() }.abi_encode();
+    let err = run_tx(&mut db, &bridge, calldata, &CAROL).unwrap_err();
+    assert!(err.matches_custom_error("FailedClaim()"));
+}
+
+/// cancelDeposit zero-amount: succeeds, processed set, no balance delta to claimee
+#[test]
+fn test_eth_bridge_cancel_deposit_zero_amount_succeeds_no_balance_change() {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    for user in [ALICE, BOB, CAROL] { add_balance_to_db(&mut db, user, 1e18 as u64); }
+    let publisher = Address::from([0x44; 20]);
+    add_balance_to_db(&mut db, publisher, 1e18 as u64);
+
+    let bytecode_ss = get_bytecode("hydra_l2_signal_service");
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let signal_service = deploy_contract(&mut db, bytecode_ss, Some((publisher, this_address).abi_encode())).unwrap();
+    let counterpart = Address::from([0x22; 20]);
+    let bridge = deploy_contract(&mut db, get_bytecode("hydra_l2_bridge"), Some((signal_service, counterpart).abi_encode())).unwrap();
+
+    use r55::test_utils::{add_balance_preserve_code, AccountInfo};
+    add_balance_preserve_code(&mut db, bridge, 1_000_000);
+
+    let claimee = BOB;
+    let eth_deposit = ETHDeposit { nonce: U256::from(1u64), from: ALICE, to: Address::from([0x33; 20]), amount: U256::from(0u64), data: Bytes::from_static(b"d"), context: Bytes::from_static(b"c"), canceler: CAROL };
+    let id: FixedBytes<32> = {
+        let t = (eth_deposit.nonce, eth_deposit.from, eth_deposit.to, eth_deposit.amount,
+                 eth_deposit.data.clone(), eth_deposit.context.clone(), eth_deposit.canceler);
+        FixedBytes::<32>::from(keccak256(&t.abi_encode()))
+    };
+    let (account_proof, storage_proof, state_root) = build_signal_proof(this_address, counterpart, id);
+    sol! { function sendSignal(bytes32 value) returns (bytes32); }
+    let _ = run_tx(&mut db, &signal_service, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    let pre = db.basic(claimee).unwrap().unwrap_or(AccountInfo::from_balance(U256::from(0))).balance;
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+    let calldata = cancelDepositCall { ethDeposit: eth_deposit, claimee, proof: proof_bytes.into() }.abi_encode();
+    let res = run_tx(&mut db, &bridge, calldata, &CAROL).unwrap();
+    assert!(res.status);
+
+    // processed flag set
+    let processed_call = processedCall { id };
+    let processed_res = run_tx(&mut db, &bridge, processed_call.abi_encode(), &ALICE).unwrap();
+    let flag: bool = bool::abi_decode(&processed_res.output, true).unwrap();
+    assert!(flag);
+
+    let post = db.basic(claimee).unwrap().unwrap_or(AccountInfo::from_balance(U256::from(0))).balance;
+    assert_eq!(post, pre, "zero-amount cancel must not change balance");
+}

--- a/r55/tests/hydra-l2-signal-service.rs
+++ b/r55/tests/hydra-l2-signal-service.rs
@@ -1,0 +1,565 @@
+//! # SignalService Tests (R55/RISC-V)
+//!
+//! Purpose: Validate the standalone semantics of the `SignalService` contract.
+//!
+//! Covered behavior:
+//! - `sendSignal(bytes32)` stores a sender-specific flag and emits `SignalSent`.
+//! - `isSignalStored(bytes32,address)` returns whether `(sender,value)` was signaled.
+//! - `verifySignal(address,bytes32,bytes)` gates by publisher-signed state root and
+//!   verifies Merkle-Patricia-Trie (MPT) proofs for the storage slot derived from
+//!   `(value,sender)` (ERC-7201 namespacing).
+//!
+//! Proofs built in tests:
+//! - Negative gates: missing publisher root, non-publisher root, empty accountProof,
+//!   ABI decode failure, and invalid account proof.
+//! - Positive path: we construct the storage trie (slot -> RLP(1)) and the account
+//!   trie (account key -> RLP(nonce,balance,storageRoot,codeHash)), compute the
+//!   state root, and ABI-encode the proofs expected by the contract.
+//!
+//! Structure:
+//! - Minimal RLP helpers (just enough to encode account/storage leaf values)
+//! - Setup fixture that deploys `SignalService`
+//! - sendSignal, isSignalStored tests
+//! - verifySignal negative matrix + positive MPT proof
+//! - Cross-function checks
+//!
+//! Integration note:
+//! These tests focus on SignalService correctness. Bridge integration tests live
+//! in `r55/tests/hydra-l2-bridge.rs` and only rely on `verifySignal` behavior
+//! at the API surface.
+
+use alloy_primitives::{Address, FixedBytes, B256, U256, keccak256, Bytes, hex};
+use r55::{
+    exec::{deploy_contract, run_tx},
+    get_bytecode,
+    test_utils::{add_balance_to_db, initialize_logger, ALICE, BOB, CAROL},
+};
+use alloy_sol_types::{sol, SolCall, SolValue};
+use revm::InMemoryDB;
+use tracing::info;
+use alloy_trie::HashBuilder;
+use alloy_trie::proof::ProofRetainer;
+use nybbles::Nibbles;
+// --- RLP helpers (minimal) ---
+// We only encode the subset needed for account/storage leaf values.
+fn rlp_bytes(input: &[u8]) -> Vec<u8> {
+    if input.len() == 1 && input[0] < 0x80 { return vec![input[0]]; }
+    let mut out = Vec::with_capacity(1 + input.len());
+    out.push(0x80 + (input.len() as u8));
+    out.extend_from_slice(input);
+    out
+}
+
+fn rlp_uint_zero() -> Vec<u8> { vec![0x80] }
+
+fn rlp_list(items: &[Vec<u8>]) -> Vec<u8> {
+    let payload_len: usize = items.iter().map(|v| v.len()).sum();
+    let mut out = Vec::with_capacity(2 + payload_len);
+    if payload_len <= 55 {
+        out.push(0xc0 + (payload_len as u8));
+    } else {
+        // long form with 1-byte length (payload < 256)
+        out.push(0xf7 + 1);
+        out.push(payload_len as u8);
+    }
+    for v in items { out.extend_from_slice(v); }
+    out
+}
+
+// Test suite for SignalService (examples/hydra-l2-signal-service/src/lib.rs)
+// Organization:
+// - Setup helpers
+// - sendSignal tests
+// - isSignalStored tests
+// - verifySignal tests (negative boundary + happy path)
+// - Cross-function behavior
+
+sol! {
+    function sendSignal(bytes32 value) returns (bytes32);
+    function isSignalStored(bytes32 value, address sender) returns (bool);
+    function verifySignal(address sender, bytes32 value, bytes proof);
+}
+
+struct SignalServiceSetup {
+    db: InMemoryDB,
+    contract: Address,
+    state_root_publisher: Address,
+}
+
+fn signal_service_setup() -> SignalServiceSetup {
+    initialize_logger();
+    let mut db = InMemoryDB::default();
+
+    // Fund user accounts with some ETH
+    for user in [ALICE, BOB, CAROL] {
+        add_balance_to_db(&mut db, user, 1e18 as u64);
+    }
+
+    // Create mock state root publisher
+    let state_root_publisher = Address::from([0x33; 20]);
+    // Fund publisher as well (calls may originate from it)
+    add_balance_to_db(&mut db, state_root_publisher, 1e18 as u64);
+
+    // Deploy SignalService contract with constructor parameters
+    let bytecode = get_bytecode("hydra_l2_signal_service");
+    // Pass both required constructor args: (state_root_publisher, this_address)
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let constructor_args = (state_root_publisher, this_address).abi_encode();
+    let contract = deploy_contract(&mut db, bytecode, Some(constructor_args)).unwrap();
+
+    SignalServiceSetup {
+        db,
+        contract,
+        state_root_publisher,
+    }
+}
+
+// === Function: sendSignal(bytes32) ===
+// Happy-path: returns derived slot and emits SignalSent
+#[test]
+fn test_send_signal_basic() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Test sendSignal function
+    let value = FixedBytes::<32>::from([0x42; 32]);
+    let call = sendSignalCall { value };
+    let result = run_tx(&mut db, &contract, call.abi_encode(), &ALICE).unwrap();
+    
+    assert!(result.status);
+    let slot: FixedBytes<32> = FixedBytes::<32>::abi_decode(&result.output, true).unwrap();
+    
+    // Verify the slot is not zero
+    assert_ne!(slot, FixedBytes::<32>::ZERO, "Signal slot should not be zero");
+    
+    info!("Signal sent with slot: {:?}", slot);
+}
+
+// Compute the same storage slot derivation used by the contract
+fn derive_key_test(value: FixedBytes<32>, account: Address) -> FixedBytes<32> {
+    use alloy_sol_types::SolValue;
+    // namespace = abi.encodePacked(value, account)
+    let namespace = (value, account).abi_encode_packed();
+
+    // slot = keccak256( (keccak256(namespace) - 1) ) & ~0xff
+    let namespace_hash = keccak256(&namespace);
+    let word = U256::from_be_bytes(namespace_hash.0);
+    let (minus_one, _) = word.overflowing_sub(U256::from(1u8));
+    let buf = minus_one.to_be_bytes::<32>();
+    let slot_bytes = keccak256(&buf);
+
+    // mask out the lowest 8 bits (ERC-7201 namespace alignment)
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(slot_bytes.as_slice());
+    let last = arr.len() - 1;
+    arr[last] = 0u8;
+    FixedBytes::<32>::from(arr)
+}
+
+// Returns slot parity with contract's derive_key; validates SignalSent topics/data
+#[test]
+fn test_send_signal_event_and_slot() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Arrange
+    let value = FixedBytes::<32>::from([0xAA; 32]);
+    let sender = ALICE;
+
+    // Act
+    let call = sendSignalCall { value };
+    let result = run_tx(&mut db, &contract, call.abi_encode(), &sender).unwrap();
+
+    // Assert returned slot equals derived slot formula
+    let returned_slot: FixedBytes<32> = FixedBytes::<32>::abi_decode(&result.output, true).unwrap();
+    let expected_slot = derive_key_test(value, sender);
+    assert_eq!(returned_slot, expected_slot, "slot derivation must match");
+
+    // Assert event SignalSent(address,bytes32)
+    // topic0 = keccak256("SignalSent(address,bytes32)")
+    let topic0 = B256::from(keccak256(b"SignalSent(address,bytes32)"));
+    let logs = result.logs;
+    assert_eq!(logs.len(), 1, "expected a single SignalSent log");
+    assert_eq!(logs[0].topics()[0], topic0, "event signature mismatch");
+    // indexed sender in topic1
+    let mut padded = [0u8; 32];
+    padded[12..].copy_from_slice(sender.as_slice());
+    assert_eq!(logs[0].topics()[1], B256::from_slice(&padded), "indexed sender mismatch");
+    // value (non-indexed) in data
+    assert_eq!(logs[0].data.data.as_ref(), value.as_slice(), "value in data mismatch");
+}
+
+// === Function: isSignalStored(bytes32,address) ===
+// Happy-path and negative for different sender
+#[test]
+fn test_is_signal_stored_basic() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // First send a signal
+    let value = FixedBytes::<32>::from([0x42; 32]);
+    let send_call = sendSignalCall { value };
+    let send_result = run_tx(&mut db, &contract, send_call.abi_encode(), &ALICE).unwrap();
+    assert!(send_result.status);
+    
+    // Now check if the signal is stored
+    let check_call = isSignalStoredCall {
+        value,
+        sender: ALICE,
+    };
+    let check_result = run_tx(&mut db, &contract, check_call.abi_encode(), &BOB).unwrap();
+    
+    assert!(check_result.status);
+    let is_stored: bool = bool::abi_decode(&check_result.output, true).unwrap();
+    assert!(is_stored, "Signal should be stored after sending");
+    
+    // Check with different sender - should return false
+    let check_call2 = isSignalStoredCall {
+        value,
+        sender: BOB,
+    };
+    let check_result2 = run_tx(&mut db, &contract, check_call2.abi_encode(), &CAROL).unwrap();
+    
+    assert!(check_result2.status);
+    let is_stored2: bool = bool::abi_decode(&check_result2.output, true).unwrap();
+    assert!(!is_stored2, "Signal should not be stored for different sender");
+}
+
+// === Function: verifySignal(address,bytes32,bytes) ===
+// Negative: ABI-decodable proof with non-empty accountProof, but the state root was
+// not signaled by the publisher -> must revert with StateRootNotFound.
+#[test]
+fn test_verify_signal_missing_publisher_gates() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Prepare decodable proof with non-empty accountProof
+    let state_root = FixedBytes::<32>::from([0xAA; 32]);
+    let account_proof: Vec<Bytes> = vec![Bytes::from_static(b"x")];
+    let storage_proof: Vec<Bytes> = vec![];
+    use alloy_sol_types::SolValue;
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+
+    let call = verifySignalCall { sender: ALICE, value: FixedBytes::<32>::from([0x42; 32]), proof: proof_bytes.into() };
+    let err = run_tx(&mut db, &contract, call.abi_encode(), &BOB).expect_err("should revert: publisher did not signal state root");
+    assert!(err.matches_custom_error("StateRootNotFound()"));
+}
+
+// === Cross-function behavior ===
+// Multiple independent signals across different senders
+#[test]
+fn test_cross_multiple_signals() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Send multiple signals from different senders
+    let values = [
+        FixedBytes::<32>::from([0x01; 32]),
+        FixedBytes::<32>::from([0x02; 32]),
+        FixedBytes::<32>::from([0x03; 32]),
+    ];
+    
+    let senders = [ALICE, BOB, CAROL];
+    
+    for (i, (value, sender)) in values.iter().zip(senders.iter()).enumerate() {
+        let call = sendSignalCall { value: *value };
+        let result = run_tx(&mut db, &contract, call.abi_encode(), sender).unwrap();
+        assert!(result.status);
+        
+        // Verify the signal is stored
+        let check_call = isSignalStoredCall {
+            value: *value,
+            sender: *sender,
+        };
+        let check_result = run_tx(&mut db, &contract, check_call.abi_encode(), &ALICE).unwrap();
+        assert!(check_result.status);
+        
+        let is_stored: bool = bool::abi_decode(&check_result.output, true).unwrap();
+        assert!(is_stored, "Signal {} should be stored", i);
+    }
+}
+
+// verifySignal must require the state root to have been signaled by the PUBLISHER, not any address
+#[test]
+fn test_verify_signal_non_publisher_state_root_fails() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Non-publisher (ALICE) signals the state root
+    let state_root = FixedBytes::<32>::from([0xAB; 32]);
+    run_tx(&mut db, &contract, sendSignalCall { value: state_root }.abi_encode(), &ALICE).unwrap();
+
+    // Build a valid-looking proof referencing that state root
+    use alloy_sol_types::SolValue;
+    let account_proof: Vec<Bytes> = vec![Bytes::from_static(b"ok")];
+    let storage_proof: Vec<Bytes> = vec![];
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+
+    // Should still revert because publisher didn't signal this state root
+    let call = verifySignalCall { sender: BOB, value: FixedBytes::<32>::from([0xCD; 32]), proof: proof_bytes.into() };
+    let err = run_tx(&mut db, &contract, call.abi_encode(), &CAROL).expect_err("non-publisher state root should fail");
+    assert!(err.matches_custom_error("StateRootNotFound()"));
+}
+
+// For the same sender, different values must map to different slots and both be stored
+#[test]
+fn test_send_signal_distinct_values_slots() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+    let sender = ALICE;
+
+    let v1 = FixedBytes::<32>::from([0x01; 32]);
+    let v2 = FixedBytes::<32>::from([0x02; 32]);
+
+    let r1 = run_tx(&mut db, &contract, sendSignalCall { value: v1 }.abi_encode(), &sender).unwrap();
+    let r2 = run_tx(&mut db, &contract, sendSignalCall { value: v2 }.abi_encode(), &sender).unwrap();
+
+    let s1: FixedBytes<32> = FixedBytes::<32>::abi_decode(&r1.output, true).unwrap();
+    let s2: FixedBytes<32> = FixedBytes::<32>::abi_decode(&r2.output, true).unwrap();
+    assert_ne!(s1, s2, "distinct values must yield distinct storage slots");
+
+    // Check both stored flags are true
+    let c1 = isSignalStoredCall { value: v1, sender };
+    let c2 = isSignalStoredCall { value: v2, sender };
+    let o1: bool = bool::abi_decode(&run_tx(&mut db, &contract, c1.abi_encode(), &sender).unwrap().output, true).unwrap();
+    let o2: bool = bool::abi_decode(&run_tx(&mut db, &contract, c2.abi_encode(), &sender).unwrap().output, true).unwrap();
+    assert!(o1 && o2);
+}
+
+// Zero bytes32 input should be accepted and stored
+#[test]
+fn test_send_signal_zero_value() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    let zero = FixedBytes::<32>::ZERO;
+    run_tx(&mut db, &contract, sendSignalCall { value: zero }.abi_encode(), &ALICE).unwrap();
+    let check = isSignalStoredCall { value: zero, sender: ALICE };
+    let stored: bool = bool::abi_decode(&run_tx(&mut db, &contract, check.abi_encode(), &ALICE).unwrap().output, true).unwrap();
+    assert!(stored);
+}
+
+// Negative: verifySignal must revert on ABI-decode failure of the proof blob
+#[test]
+fn test_verify_signal_decode_failure() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Garbage bytes (not ABI of (bytes[],bytes[],bytes32))
+    let bad_proof = Bytes::from_static(b"not-an-abi-encoded-proof");
+    let call = verifySignalCall { sender: ALICE, value: FixedBytes::<32>::from([0xEE; 32]), proof: bad_proof };
+    let err = run_tx(&mut db, &contract, call.abi_encode(), &BOB).expect_err("ABI decode failure should revert");
+    // Generic revert with empty data
+    assert!(err.matches_string_error(""));
+}
+#[test]
+fn test_verify_signal_state_root_not_found() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    // Create proof with non-empty accountProof but missing state root signal
+    let state_root = FixedBytes::<32>::from([0x55; 32]);
+    let account_proof: Vec<Bytes> = vec![Bytes::from(b"ap".as_slice())];
+    let storage_proof: Vec<Bytes> = vec![];
+    use alloy_sol_types::SolValue;
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+
+    let call = verifySignalCall { sender: ALICE, value: FixedBytes::<32>::from([0x11; 32]), proof: proof_bytes.into() };
+    let err = run_tx(&mut db, &contract, call.abi_encode(), &BOB).expect_err("should revert: state root not signaled");
+
+    assert!(err.matches_custom_error("StateRootNotFound()"));
+}
+
+#[test]
+fn test_verify_signal_account_proof_empty() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+    let publisher = setup.state_root_publisher;
+
+    // First signal the state root from the publisher
+    let state_root = FixedBytes::<32>::from([0x66; 32]);
+    let send = sendSignalCall { value: state_root };
+    run_tx(&mut db, &contract, send.abi_encode(), &publisher).unwrap();
+
+    // Build proof with empty accountProof
+    let account_proof: Vec<Bytes> = vec![];
+    let storage_proof: Vec<Bytes> = vec![];
+    use alloy_sol_types::SolValue;
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+
+    let call = verifySignalCall { sender: ALICE, value: FixedBytes::<32>::from([0x22; 32]), proof: proof_bytes.into() };
+    let err = run_tx(&mut db, &contract, call.abi_encode(), &BOB).expect_err("should revert: empty accountProof");
+    assert!(err.matches_custom_error("AccountProofEmpty()"));
+}
+
+// With real verification enabled, a dummy proof must fail with INVALID_ACCOUNT_PROOF()
+#[test]
+fn test_verify_signal_invalid_account_proof() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+    let publisher = setup.state_root_publisher;
+
+    // State root signaled by publisher
+    let state_root = FixedBytes::<32>::from([0x77; 32]);
+    let _ = run_tx(&mut db, &contract, sendSignalCall { value: state_root }.abi_encode(), &publisher).unwrap();
+
+    // Non-empty accountProof -> passes basic checks
+    let account_proof: Vec<Bytes> = vec![Bytes::from_static(b"proof")];
+    let storage_proof: Vec<Bytes> = vec![];
+    use alloy_sol_types::SolValue;
+    let proof_bytes = (account_proof, storage_proof, state_root).abi_encode();
+
+    let sender = BOB;
+    let signal_value = FixedBytes::<32>::from([0x33; 32]);
+    let call = verifySignalCall { sender, value: signal_value, proof: proof_bytes.into() };
+    let err = run_tx(&mut db, &contract, call.abi_encode(), &CAROL).expect_err("should fail with invalid account proof");
+    assert!(err.matches_custom_error("INVALID_ACCOUNT_PROOF()"));
+}
+
+// Positive MPT path: build account/storage tries matching the contract’s expectations.
+// Steps:
+// 1) Compute the storage slot for (sender,value) per ERC-7201.
+// 2) Build storage trie leaf: keccak(slot) -> RLP(1).
+// 3) Build account trie leaf: keccak(this_address) -> RLP(nonce,balance,storageRoot,codeHash).
+// 4) Publisher signals the resulting state root via sendSignal.
+// 5) ABI-encode (accountProof, storageProof, stateRoot) and call verifySignal.
+#[test]
+fn test_verify_signal_positive_mpt_proof() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+    let publisher = setup.state_root_publisher;
+
+    // Sender/value pair we will prove
+    let sender = ALICE;
+    let value = FixedBytes::<32>::from([0x5A; 32]);
+
+    // Compute derived slot and hashed storage key
+    let slot = derive_key_test(value, sender);
+    let storage_key_hashed = B256::from(keccak256(slot.as_slice()));
+
+    // Build storage trie: key -> RLP(1)
+    let mut storage_builder = HashBuilder::default().with_proof_retainer(ProofRetainer::from_iter([Nibbles::unpack(storage_key_hashed.as_slice())]));
+    let rlp_one = alloy_rlp::encode(U256::from(1u64));
+    storage_builder.add_leaf(Nibbles::unpack(storage_key_hashed.as_slice()), &rlp_one);
+    let storage_root = storage_builder.root();
+    let storage_proof_nodes = storage_builder.take_proof_nodes().into_nodes_sorted();
+    let storage_proof: Vec<Bytes> = storage_proof_nodes.into_iter().map(|(_, n)| Bytes::from(n.to_vec())).collect();
+
+    // Build account trie: key keccak(this_address) -> RLP(nonce,balance,storage_root,code_hash)
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let account_key = B256::from(keccak256(this_address.as_slice()));
+    // Manually RLP-encode (nonce, balance, storageRoot, codeHash)
+    let account_value_rlp = rlp_list(&[
+        rlp_uint_zero(),
+        rlp_uint_zero(),
+        rlp_bytes(storage_root.as_slice()),
+        rlp_bytes([0u8;32].as_slice()),
+    ]);
+    let mut account_builder = HashBuilder::default().with_proof_retainer(ProofRetainer::from_iter([Nibbles::unpack(account_key.as_slice())]));
+    account_builder.add_leaf(Nibbles::unpack(account_key.as_slice()), &account_value_rlp);
+    let state_root = account_builder.root();
+    let account_proof_nodes = account_builder.take_proof_nodes().into_nodes_sorted();
+    let account_proof: Vec<Bytes> = account_proof_nodes.into_iter().map(|(_, n)| Bytes::from(n.to_vec())).collect();
+
+    // Publisher signals the state root
+    let _ = run_tx(&mut db, &contract, sendSignalCall { value: FixedBytes::<32>::from(state_root.0) }.abi_encode(), &publisher).unwrap();
+
+    // verifySignal expects ABI((bytes[] accountProof, bytes[] storageProof, bytes32 stateRoot))
+    use alloy_sol_types::SolValue;
+    let proof_bytes = (account_proof, storage_proof, FixedBytes::<32>::from(state_root.0)).abi_encode();
+    let call = verifySignalCall { sender, value, proof: proof_bytes.into() };
+    let res = run_tx(&mut db, &contract, call.abi_encode(), &BOB).unwrap();
+
+    // Check SignalVerified event
+    let topic0 = B256::from(keccak256(b"SignalVerified(address,bytes32)"));
+    assert_eq!(res.logs.len(), 1);
+    assert_eq!(res.logs[0].topics()[0], topic0);
+    let mut padded = [0u8; 32];
+    padded[12..].copy_from_slice(sender.as_slice());
+    assert_eq!(res.logs[0].topics()[1], B256::from_slice(&padded));
+    assert_eq!(res.logs[0].data.data.as_ref(), value.as_slice());
+}
+
+// Negative storage inclusion: wrong storage value (expect RLP(1), provide RLP(0))
+#[test]
+fn test_verify_signal_invalid_storage_inclusion() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+    let publisher = setup.state_root_publisher;
+
+    // Sender/value pair we will attempt to prove incorrectly
+    let sender = ALICE;
+    let value = FixedBytes::<32>::from([0x6A; 32]);
+
+    // Compute derived slot and hashed storage key
+    let slot = derive_key_test(value, sender);
+    let storage_key_hashed = B256::from(keccak256(slot.as_slice()));
+
+    // Build storage trie: key -> RLP(0) (incorrect)
+    let mut storage_builder = HashBuilder::default().with_proof_retainer(ProofRetainer::from_iter([Nibbles::unpack(storage_key_hashed.as_slice())]));
+    let rlp_zero = alloy_rlp::encode(U256::from(0u64));
+    storage_builder.add_leaf(Nibbles::unpack(storage_key_hashed.as_slice()), &rlp_zero);
+    let storage_root = storage_builder.root();
+    let storage_proof_nodes = storage_builder.take_proof_nodes().into_nodes_sorted();
+    let storage_proof: Vec<Bytes> = storage_proof_nodes.into_iter().map(|(_, n)| Bytes::from(n.to_vec())).collect();
+
+    // Build account trie: key keccak(this_address) -> RLP(nonce,balance,storage_root,code_hash)
+    let this_address = Address::from_slice(&hex!("f6a171f57acac30c292e223ea8adbb28abd3e14d"));
+    let account_key = B256::from(keccak256(this_address.as_slice()));
+    let account_value_rlp = rlp_list(&[
+        rlp_uint_zero(),
+        rlp_uint_zero(),
+        rlp_bytes(storage_root.as_slice()),
+        rlp_bytes([0u8;32].as_slice()),
+    ]);
+    let mut account_builder = HashBuilder::default().with_proof_retainer(ProofRetainer::from_iter([Nibbles::unpack(account_key.as_slice())]));
+    account_builder.add_leaf(Nibbles::unpack(account_key.as_slice()), &account_value_rlp);
+    let state_root = account_builder.root();
+    let account_proof_nodes = account_builder.take_proof_nodes().into_nodes_sorted();
+    let account_proof: Vec<Bytes> = account_proof_nodes.into_iter().map(|(_, n)| Bytes::from(n.to_vec())).collect();
+
+    // Publisher signals the state root
+    let _ = run_tx(&mut db, &contract, sendSignalCall { value: FixedBytes::<32>::from(state_root.0) }.abi_encode(), &publisher).unwrap();
+
+    // Call verifySignal: must revert with INVALID_INCLUSION_PROOF()
+    use alloy_sol_types::SolValue;
+    let proof_bytes = (account_proof, storage_proof, FixedBytes::<32>::from(state_root.0)).abi_encode();
+    let call = verifySignalCall { sender, value, proof: proof_bytes.into() };
+    let err = run_tx(&mut db, &contract, call.abi_encode(), &BOB).expect_err("invalid storage inclusion should revert");
+    assert!(err.matches_custom_error("INVALID_INCLUSION_PROOF()"));
+}
+
+#[test]
+fn test_send_signal_idempotent() {
+    let setup = signal_service_setup();
+    let mut db = setup.db;
+    let contract = setup.contract;
+
+    let value = FixedBytes::<32>::from([0x99; 32]);
+    let sender = ALICE;
+
+    // First send
+    let _ = run_tx(&mut db, &contract, sendSignalCall { value }.abi_encode(), &sender).unwrap();
+    // Second send with same value
+    let _ = run_tx(&mut db, &contract, sendSignalCall { value }.abi_encode(), &sender).unwrap();
+
+    // Check stored flag still true
+    let check_call = isSignalStoredCall { value, sender };
+    let result = run_tx(&mut db, &contract, check_call.abi_encode(), &sender).unwrap();
+    let is_stored: bool = bool::abi_decode(&result.output, true).unwrap();
+    assert!(is_stored);
+}


### PR DESCRIPTION
## Summary

I have been using our R55 fork to write/test contracts in isolation before verifying Hydra n=1/n=2 parity.

This PR introduces the `ETHBridge` and `SignalService` contracts in pure Rust (R55/RISC-V), adds full test coverage, and hardens the execution runner so nested R55→R55 calls behave correctly and safely. These runner changes were required for my bridge/signal tests to pass.

Also fixes a minor bug in R55’s test infra where topping up an account balance via `insert_account_info` would inadvertently wipe its deployed code, causing “empty TxResult”

## Key Changes

### Contracts

- `hydra-l2-bridge`: Implements deposit, claim, cancel flows with event emission; mirrors Solidity logic with ABI and event parity
- `hydra-l2-signal-service`: Implements signal send/query and proof verification against signaled state roots using RLP/MPT helpers

### Runner (`r55/src/exec.rs`)

To clarify, this file is not part of the `r55-compile` pipeline; it implements the runtime integration layer that executes R55/RISC-V contracts within `revm`. While testing nested flows (`ETHBridge.claimDeposit() → SignalService.verifySignal()`), I ran into several errors with regards to gas accounting and unguarded memory access. Hardening included:

- Correct EIP-150 gas semantics for nested `CALL/CREATE` (parent pays only base cost; callee gas = remaining − remaining/64; pre-deducted in parent).
- `Syscall::Return`: guard underflow; spend remaining and return `OutOfGas` instead of panicking
- Memory safety: clamp `RETURNDATACOPY` and DRAM slices to avoid overflow/OOB in `rvemu`

These changes are low-level and touch core execution paths; worth careful review, though ongoing maintenance may not be required. 

### Tests/Test Utils
- Comprehensive tests: `r55/tests/hydra-l2-bridge.rs` + `r55/tests/hydra-l2-signal-service.rs`: happy paths and revert cases; detailed event assertions
- Uses `add_balance_preserve_code` to fund accounts without clearing deployed code
- Adjusted tests to use EOAs (not precompiles) as transfer recipients (avoids R55 error)

---

### Known Gap (follow‑up required)

**Interface call discrepancy (works in R55, reverts in Hydra)**

- The syntax for executing a Contract -> Contract call ie. `ISignalService::new(signal_service).with_ctx(&*self).verifySignal(counterpart, id, proof)` succeeds in R55 but reverts in Hydra
- I need to set up a toy example to further debug

**Hypothesis**
- Likely points to an issue we've seen -> ABI/calldata mismatch between interface and manual call

**Workaround**
- Use `sol!` macro to manually encode calldata + `eth_riscv_runtime::call_contract` directly. Example:

```
        alloy_sol_types::sol! { function verifySignal(address sender, bytes32 value, bytes proof); }
        let calldata_vec = verifySignalCall {
            sender: counterpart,
            value: id,
            proof: proof.clone(),
        }
        .abi_encode();
        let calldata = Bytes::from(calldata_vec);
        let verify_ret = call_contract(signal_service, 0, &calldata, None);
```