### PR TITLE
fix: correct interface calldata encoding in contract-derive

### DIFF
--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -214,9 +214,23 @@ fn generate_method_impl(
                 #method_selector.to_be_bytes()[3],
             ]);
         }
-    } else {
+    } else if arg_names.len() == 1 {
+        // Single-argument: use abi_encode() (equivalent to abi.encode(arg))
         quote! {
             let mut args_calldata = (#(#arg_names),*).abi_encode();
+            let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
+            complete_calldata.extend_from_slice(&[
+                #method_selector.to_be_bytes()[0],
+                #method_selector.to_be_bytes()[1],
+                #method_selector.to_be_bytes()[2],
+                #method_selector.to_be_bytes()[3],
+            ]);
+            complete_calldata.append(&mut args_calldata);
+        }
+    } else {
+        // Multi-argument: encode as standard Solidity params (abi.encode(a,b,...))
+        quote! {
+            let mut args_calldata = (#(#arg_names),*).abi_encode_params();
             let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
             complete_calldata.extend_from_slice(&[
                 #method_selector.to_be_bytes()[0],


### PR DESCRIPTION
Hi @sam-iamm,

Debugged the issue today and it was exactly what we suspected: the `interface` macro was encoding calldata as a tuple (`abi.encode((args...))`) instead of Solidity’s function ABI (`abi.encode(a,b,...)`)

**Fix**

* Adjust `fn generate_method_impl` to encode interface calldata by argument count to match Solidity:

  * 0 args → selector only
  * 1 arg → `(#arg).abi_encode()` (`abi.encode(arg)`)
  * 2+ args → `(#args).abi_encode_params()` (`abi.encode(a,b,...)`)
* Reason: `.abi_encode_params()` on a single arg fails alloy’s `TokenSeq` bound, so the path is split

**Why (Hydra)**

* This was the main cause of my `ExecutionLogMismatch` errors on contract -> contract calls ie. `ETHBridge → SignalService`
* Parallel (R55) was sending tuple-encoded calldata for multi-arg calls, while base (Solidity) sent params-encoded. Hydra naturally flags a mismatch

**Impact**

* Minimal change, isolated to interface calldata generation
* No selector changes; 0/1-arg behavior remains correct
* The fix I applied follows a similar pattern as the ABI decoding change from a few weeks ago: https://github.com/sam-iamm/r55/pull/6



Let me know what you think of the changes, and if you’re good with this I’ll merge and then set up some proper tests in Hydra (rather than testing in our R55 fork)