### PR TITLE
r55(feat): propagate call success status via a0 register

### DIFF
--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -254,7 +254,7 @@ fn generate_method_impl(
         )
     };
 
-    // Generate different implementations based on return type
+    // Generate implementations handling Result<Bytes, Bytes> from call_contract.
     match extract_wrapper_types(&method.return_type) {
         // If `Result<T, E>` handle each individual type
         WrapperType::Result(ok_type, err_type) => quote! {
@@ -271,9 +271,14 @@ fn generate_method_impl(
                     None
                 );
 
-                match <#ok_type>::abi_decode(&result) {
-                    Ok(decoded) => Ok(decoded),
-                    Err(_) => Err(<#err_type>::abi_decode(&result, true))
+                match result {
+                    // Call succeeded - decode return data
+                    Ok(bytes) => match <#ok_type>::abi_decode(&bytes) {
+                        Ok(decoded) => Ok(decoded),
+                        Err(_) => Err(<#err_type>::abi_decode(&bytes, true))
+                    },
+                    // Call reverted - return error (no auto-revert, user handles Result)
+                    Err(revert_data) => Err(<#err_type>::abi_decode(&revert_data, true))
                 }
             }
         },
@@ -293,9 +298,16 @@ fn generate_method_impl(
                         None
                     );
 
-                    match <#return_ty>::abi_decode(&result) {
-                        Ok(decoded) => Some(decoded),
-                        Err(_) => None
+                    match result {
+                        // Call succeeded - decode and return
+                        Ok(bytes) => match <#return_ty>::abi_decode(&bytes) {
+                            Ok(decoded) => Some(decoded),
+                            Err(_) => None
+                        },
+                        // Call reverted - auto-propagate (if A→B reverts, A reverts)
+                        Err(revert_data) => {
+                            eth_riscv_runtime::revert_with_error(&revert_data);
+                        }
                     }
                 }
             }
@@ -320,9 +332,16 @@ fn generate_method_impl(
                         None
                     );
 
-                    match <#return_ty>::abi_decode(&result) {
-                        Ok(decoded) => Some(decoded),
-                        Err(_) => None
+                    match result {
+                        // Call succeeded - decode and return
+                        Ok(bytes) => match <#return_ty>::abi_decode(&bytes) {
+                            Ok(decoded) => Some(decoded),
+                            Err(_) => None
+                        },
+                        // Call reverted - auto-propagate
+                        Err(revert_data) => {
+                            eth_riscv_runtime::revert_with_error(&revert_data);
+                        }
                     }
                 }
             }

--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -255,6 +255,14 @@ fn generate_method_impl(
     };
 
     // Generate implementations handling Result<Bytes, Bytes> from call_contract.
+    // The `result` variable is the direct output of `call_contract`, which returns `Ok` or `Err`
+    // based on the success flag read from the a0 register.
+    //
+    // The generated error handling depends on the function's return type. This provides a
+    // choice between manual error handling and automatic revert propagation (like Solidity).
+    // - `Result<T, E>`: Decodes and returns the `Err`, letting the developer handle the failure.
+    // - `Option<T>` or default: Automatically reverts the transaction on failure.
+    // Reference: https://github.com/sam-iamm/r55/pull/9
     match extract_wrapper_types(&method.return_type) {
         // If `Result<T, E>` handle each individual type
         WrapperType::Result(ok_type, err_type) => quote! {

--- a/eth-riscv-runtime/src/call.rs
+++ b/eth-riscv-runtime/src/call.rs
@@ -69,16 +69,24 @@ pub trait Contract {
     fn call_with_data(&mut self, calldata: &[u8]);
 }
 
+/// Call contract and return Result based on success flag in a0 register.
+/// - Ok(Bytes): call succeeded
+/// - Err(Bytes): call reverted (enables automatic revert propagation)
 pub fn call_contract(
     addr: Address,
     value: u64,
     data: &[u8],
     ret_size: Option<u64>,
-) -> Bytes {
-    // Perform the call without writing return data into (REVM) memory
+) -> Result<Bytes, Bytes> {
     call(addr, value, data.as_ptr() as u64, data.len() as u64);
-    // Load call output to memory
-    handle_call_output(ret_size)
+    
+    // Read success from a0 immediately (written by EVM in return_result)
+    // Avoids race condition with other syscalls that might clobber a0
+    let success: u64;
+    unsafe { asm!("mv {out}, a0", out = lateout(reg) success); }
+    
+    let out = handle_call_output(ret_size);
+    if success == 1 { Ok(out) } else { Err(out) }
 }
 
 pub fn call(addr: Address, value: u64, data_offset: u64, data_size: u64) {
@@ -94,11 +102,15 @@ pub fn call(addr: Address, value: u64, data_offset: u64, data_size: u64) {
     }
 }
 
-pub fn staticcall_contract(addr: Address, value: u64, data: &[u8], ret_size: Option<u64>) -> Bytes {
-    // Perform the staticcall without writing return data into (REVM) memory
+/// Staticcall contract (read-only). Same behavior as call_contract.
+pub fn staticcall_contract(addr: Address, value: u64, data: &[u8], ret_size: Option<u64>) -> Result<Bytes, Bytes> {
     staticcall(addr, value, data.as_ptr() as u64, data.len() as u64);
-    // Load call output to memory
-    handle_call_output(ret_size)
+    
+    let success: u64;
+    unsafe { asm!("mv {out}, a0", out = lateout(reg) success); }
+    
+    let out = handle_call_output(ret_size);
+    if success == 1 { Ok(out) } else { Err(out) }
 }
 
 fn handle_call_output(ret_size: Option<u64>) -> Bytes {


### PR DESCRIPTION
Hi @sam-iamm , PR is ready for review:

- Fixes nested call revert propagation: https://github.com/Firewall-eng/stack/issues/465

- Requires https://github.com/Firewall-eng/stack/pull/479 for `r55-evm` changes that write the success flag to `a0` + accompanying tests

---

**Problem**

In `r55/eth-riscv-runtime/src/call.rs`, `call_contract()` returns `Bytes` without signalling whether the call succeeded or reverted.

When executing nested calls, the `interface` macro cannot distinguish between success and failure, causing caller frames to continue executing when callees revert (instead of propagating the revert):

**Solution**

Added explicit success status via `a0` register:

**`eth-riscv-runtime/src/call.rs`:**
```rust
pub fn call_contract(...) -> Result<Bytes, Bytes> {
    call(addr, value, data.as_ptr() as u64, data.len() as u64);
    
    let success: u64;
    unsafe { asm!("mv {out}, a0", out = lateout(reg) success); }
    
    let out = handle_call_output(ret_size);
    if success == 1 { Ok(out) } else { Err(out) }
}
```

**Note:** Success flag is read from `a0` immediately after the syscall returns, before `handle_call_output()` which might invoke other syscalls that could clobber `a0`. Our `r55-evm` writes the success flag (1 or 0) to `a0` in the `return_result` method (specifically in the `FrameResult::Call` branch). This PR reads that value directly after the syscall completes. This avoids race conditions while matching RISC-V calling convention where `a0` holds the primary return value.


**`contract-derive/src/helpers.rs`:**
- `Result<T, E>`: Returns `Err(revert_data)` for explicit user handling
- `Option<T>` / default: Calls `revert_with_error(&revert_data)` for automatic propagation

Matches EVM CALL opcode behavior where the success flag is pushed to the stack

**Why (Hydra)**

Without this fix, nested calls produce execution log mismatches:
- Solidity n=1: `NestedCall → SimpleDeposit` reverts → `NestedCall` frame result is Revert
- R55 n=2: `NestedCall → SimpleDeposit` reverts → `NestedCall` frame result is Return

Hydra sees a mismatch and rejects the transaction. Fix ensures both versions produce matching `Revert` results.

---

Let me know if you have any questions or feedback on the approach. Happy to discuss alternative implementations