### PR TITLE
r55: implement dynamic storage via DynamicSlot<T>

### DIFF
--- a/eth-riscv-runtime/src/types/dynamic_slot.rs
+++ b/eth-riscv-runtime/src/types/dynamic_slot.rs
@@ -10,6 +10,8 @@ use alloy_core::primitives::Bytes;
 /// Generic dynamic storage slot that anchors a variable-length value at a base slot
 /// and stores the payload across derived slots computed as `keccak256(base || i_be)`.
 ///
+/// Where `i_be` is the u64 index encoded as big-endian (8 bytes).
+///
 /// Safety:
 /// - Length is bounded to prevent excessive allocations.
 /// - Reads honor the stored length and ignore surplus words.
@@ -40,7 +42,10 @@ impl DynamicValue for alloc::string::String {
     }
 
     fn from_storage_bytes(b: Vec<u8>) -> Self {
-        alloc::string::String::from_utf8(b).unwrap_or_default()
+        match alloc::string::String::from_utf8(b) {
+            Ok(s) => s,
+            Err(_) => revert(),
+        }
     }
 }
 
@@ -81,14 +86,14 @@ where
         // number of 32-byte words to read
         let words = (len + 31) / 32;
         let mut out = Vec::with_capacity(words * 32);
+        let base_bytes: [u8; 32] = base.to_be_bytes();
 
         for i in 0..(words as u64) {
             // key = keccak256(base || i_be)
-            let base_bytes: [u8; 32] = base.to_be_bytes();
-            let idx_bytes = i.to_be_bytes();
+            let index_be_8 = i.to_be_bytes();
             let mut buf = Vec::with_capacity(32 + 8);
             buf.extend_from_slice(&base_bytes);
-            buf.extend_from_slice(&idx_bytes);
+            buf.extend_from_slice(&index_be_8);
             let key = keccak256(buf.as_ptr() as u64, buf.len() as u64);
             let word: [u8; 32] = sload(key).to_be_bytes();
             out.extend_from_slice(&word);
@@ -99,7 +104,7 @@ where
     }
 
     fn __write(base: U256, value: Self::Value) {
-        let mut data = T::to_storage_bytes(&value);
+        let data = T::to_storage_bytes(&value);
         if data.len() > MAX_DYNAMIC_BYTES {
             revert();
         }
@@ -115,17 +120,17 @@ where
         // write 32-byte chunks, padding final chunk with zeros
         let mut offset = 0usize;
         let mut index: u64 = 0;
+        let base_bytes: [u8; 32] = base.to_be_bytes();
         while offset < data.len() {
             let remaining = data.len() - offset;
             let take = core::cmp::min(32, remaining);
             let mut chunk = [0u8; 32];
             chunk[..take].copy_from_slice(&data[offset..offset + take]);
             // key = keccak256(base || index_be)
-            let base_bytes: [u8; 32] = base.to_be_bytes();
-            let idx_bytes = index.to_be_bytes();
+            let index_be_8 = index.to_be_bytes();
             let mut buf = Vec::with_capacity(32 + 8);
             buf.extend_from_slice(&base_bytes);
-            buf.extend_from_slice(&idx_bytes);
+            buf.extend_from_slice(&index_be_8);
             let key = keccak256(buf.as_ptr() as u64, buf.len() as u64);
             sstore(key, U256::from_be_bytes(chunk));
             offset += take;

--- a/eth-riscv-runtime/src/types/dynamic_slot.rs
+++ b/eth-riscv-runtime/src/types/dynamic_slot.rs
@@ -12,16 +12,47 @@ use alloy_core::primitives::Bytes;
 ///
 /// Where `i_be` is the u64 index encoded as big-endian (8 bytes).
 ///
+/// Semantics (v1):
+/// - Length (bytes) is stored at base slot `B`.
+/// - Payload words are stored at `keccak256(B || i_be)` for `i = 0..`, padded to 32 bytes on write.
+/// - Reads return exactly the first `len` bytes and ignore any surplus words from prior larger writes.
+/// - When used under `Mapping`, the mapping guard provides `B = keccak256(key || id)`,
+///   so dynamic payload keys remain disjoint per `(contract, field, key, index)`.
+///
+/// Example (key derivation):
+/// - Let `B = 0x[32 bytes]` and `i` be the 64-bit chunk index.
+/// - For `i = 0`, `i_be = 0x0000000000000000`, key₀ = keccak256(`B || 0000000000000000`).
+/// - For `i = 1`, `i_be = 0x0000000000000001`, key₁ = keccak256(`B || 0000000000000001`).
+/// - For `i = 257`, `i_be = 0x0000000000000101`, key₂₅₇ = keccak256(`B || 0000000000000101`).
+/// Each chunk stores 32 bytes of payload at its corresponding key.
+///
 /// Safety:
 /// - Length is bounded to prevent excessive allocations.
 /// - Reads honor the stored length and ignore surplus words.
+///
+/// Notes on trait bounds:
+/// - `StorageStorable` requires `Value: SolValue + From<...>` across the runtime. The dynamic path
+///   does not use ABI encode/decode for payload; it converts via `DynamicValue`. The `SolValue`
+///   bound is retained for type coherence with other storage types.
+/// Upper bound for dynamic payload size in bytes.
+/// Rationale: conservative DoS guard for v1 to cap allocation and loop work.
+/// This is an internal runtime policy, not part of the ABI. Contracts that accept
+/// untrusted dynamic inputs should still validate lengths at the application layer.
 const MAX_DYNAMIC_BYTES: usize = 131_072; // 128 KiB upper bound for v1
+/// Layout handle for a dynamic value of type `T`.
+///
+/// `id` holds the base slot `B` that anchors the value. The macro `#[storage]`
+/// assigns `B` uniquely per field (or, under mappings, per `(field, key)`), and
+/// the dynamic payload is spread across derived keys `keccak256(B || i_be)`.
 pub struct DynamicSlot<T> {
     id: U256,
     _pd: PhantomData<T>,
 }
 
 impl<T> StorageLayout for DynamicSlot<T> {
+    /// Assign the base slot id `B` for this field. The `#[storage]` macro passes the slot id
+    /// as four limbs (U256). No hashing is performed here; hashing is deferred to per-chunk
+    /// addressing for dynamic payload words.
     fn allocate(first: u64, second: u64, third: u64, fourth: u64) -> Self {
         Self {
             id: U256::from_limbs([first, second, third, fourth]),
@@ -30,13 +61,16 @@ impl<T> StorageLayout for DynamicSlot<T> {
     }
 }
 
-/// Helper trait to convert between runtime values and their storage byte representation.
+/// Conversion layer between runtime values and their storage byte representation.
+/// Not ABI encoding; this is strictly for persistence in `DynamicSlot<T>`.
+/// Implementations must be inverses: `from_storage_bytes(to_storage_bytes(v)) == v`.
 pub trait DynamicValue {
     fn to_storage_bytes(v: &Self) -> Vec<u8>;
     fn from_storage_bytes(b: Vec<u8>) -> Self;
 }
 
 impl DynamicValue for alloc::string::String {
+    /// Persist strings as raw UTF-8 bytes. Invalid UTF-8 on read triggers a revert.
     fn to_storage_bytes(v: &Self) -> Vec<u8> {
         v.as_bytes().to_vec()
     }
@@ -50,6 +84,7 @@ impl DynamicValue for alloc::string::String {
 }
 
 impl DynamicValue for Bytes {
+    /// Persist as raw byte vector; no additional framing.
     fn to_storage_bytes(v: &Self) -> Vec<u8> {
         v.to_vec()
     }
@@ -66,7 +101,8 @@ where
     type Value = T;
 
     fn __read(base: U256) -> Self::Value {
-        // load length (in bytes) from base slot
+        // Load the authoritative length (bytes) from the base slot `B`.
+        // The length is encoded as a small U256 where only the lowest 64 bits are used in v1.
         let len_u256 = sload(base);
         let limbs = len_u256.as_limbs();
         if limbs[1] != 0 || limbs[2] != 0 || limbs[3] != 0 {
@@ -75,63 +111,73 @@ where
         }
         let len = limbs[0] as usize;
         if len == 0 {
+            // Empty value: return the default dynamic value for T from empty bytes.
             return T::from_storage_bytes(Vec::new());
         }
 
-        // Prevent excessive allocations
+        // Defensive bound: prevent unbounded allocation and read loops.
         if len > MAX_DYNAMIC_BYTES {
             revert();
         }
 
-        // number of 32-byte words to read
+        // Number of 32-byte words to read to reconstruct `len` bytes.
         let words = (len + 31) / 32;
         let mut out = Vec::with_capacity(words * 32);
         let base_bytes: [u8; 32] = base.to_be_bytes();
 
+        // Fixed-size stack buffer to avoid per-iteration heap allocation.
+        let mut buf: [u8; 40] = [0u8; 40];
+        buf[..32].copy_from_slice(&base_bytes);
+
         for i in 0..(words as u64) {
-            // key = keccak256(base || i_be)
+            // Compute per-word storage key as: key = keccak256(B || i_be),
+            // where i_be is the big-endian encoding of the 64-bit chunk index i.
             let index_be_8 = i.to_be_bytes();
-            let mut buf = Vec::with_capacity(32 + 8);
-            buf.extend_from_slice(&base_bytes);
-            buf.extend_from_slice(&index_be_8);
-            let key = keccak256(buf.as_ptr() as u64, buf.len() as u64);
+            buf[32..40].copy_from_slice(&index_be_8);
+            let key = keccak256(buf.as_ptr() as u64, 40);
             let word: [u8; 32] = sload(key).to_be_bytes();
             out.extend_from_slice(&word);
         }
 
+        // Truncate to the exact byte length and convert back to T.
+        // Any surplus words from prior longer writes are ignored by design in v1.
         out.truncate(len);
         T::from_storage_bytes(out)
     }
 
     fn __write(base: U256, value: Self::Value) {
+        // Convert runtime value into its storage byte representation.
         let data = T::to_storage_bytes(&value);
         if data.len() > MAX_DYNAMIC_BYTES {
             revert();
         }
         let len = data.len() as u64;
 
-        // store length at base slot
+        // Store the authoritative length (bytes) at base slot `B`.
         sstore(base, U256::from(len));
 
         if len == 0 {
+            // Empty value: no payload words to write.
             return;
         }
 
-        // write 32-byte chunks, padding final chunk with zeros
+        // Write 32-byte chunks to keys derived as keccak256(B || i_be), zero-padding the final chunk.
+        // v1 semantics: we do not clear surplus words from prior longer writes; the stored length governs reads.
         let mut offset = 0usize;
         let mut index: u64 = 0;
         let base_bytes: [u8; 32] = base.to_be_bytes();
+        // Fixed-size stack buffer to avoid per-iteration heap allocation.
+        let mut buf: [u8; 40] = [0u8; 40];
+        buf[..32].copy_from_slice(&base_bytes);
         while offset < data.len() {
             let remaining = data.len() - offset;
             let take = core::cmp::min(32, remaining);
             let mut chunk = [0u8; 32];
             chunk[..take].copy_from_slice(&data[offset..offset + take]);
-            // key = keccak256(base || index_be)
+            // Key derivation: key = keccak256(B || i_be), i_be is big-endian u64
             let index_be_8 = index.to_be_bytes();
-            let mut buf = Vec::with_capacity(32 + 8);
-            buf.extend_from_slice(&base_bytes);
-            buf.extend_from_slice(&index_be_8);
-            let key = keccak256(buf.as_ptr() as u64, buf.len() as u64);
+            buf[32..40].copy_from_slice(&index_be_8);
+            let key = keccak256(buf.as_ptr() as u64, 40);
             sstore(key, U256::from_be_bytes(chunk));
             offset += take;
             index += 1;
@@ -143,6 +189,10 @@ impl<T> DirectStorage<T> for DynamicSlot<T>
 where
     Self: StorageStorable<Value = T>,
 {
+    // Expose direct read/write for fields that own a base slot `B` (non-mapping fields).
+    // When used under `Mapping`, `MappingGuard<V>` implements `IndirectStorage<V>` and will
+    // call `V::__read/__write` with a derived base key (e.g., `B = keccak256(key || id)`),
+    // so `DynamicSlot<T>` composes naturally without a separate IndirectStorage impl.
     fn read(&self) -> T {
         Self::__read(self.id)
     }

--- a/eth-riscv-runtime/src/types/dynamic_slot.rs
+++ b/eth-riscv-runtime/src/types/dynamic_slot.rs
@@ -1,0 +1,150 @@
+use super::*;
+
+use core::marker::PhantomData;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use alloy_core::primitives::Bytes;
+
+/// Generic dynamic storage slot that anchors a variable-length value at a base slot
+/// and stores the payload across derived slots computed as `keccak256(base || i_be)`.
+///
+/// Safety:
+/// - Length is bounded to prevent excessive allocations.
+/// - Reads honor the stored length and ignore surplus words.
+const MAX_DYNAMIC_BYTES: usize = 131_072; // 128 KiB upper bound for v1
+pub struct DynamicSlot<T> {
+    id: U256,
+    _pd: PhantomData<T>,
+}
+
+impl<T> StorageLayout for DynamicSlot<T> {
+    fn allocate(first: u64, second: u64, third: u64, fourth: u64) -> Self {
+        Self {
+            id: U256::from_limbs([first, second, third, fourth]),
+            _pd: PhantomData::default(),
+        }
+    }
+}
+
+/// Helper trait to convert between runtime values and their storage byte representation.
+pub trait DynamicValue {
+    fn to_storage_bytes(v: &Self) -> Vec<u8>;
+    fn from_storage_bytes(b: Vec<u8>) -> Self;
+}
+
+impl DynamicValue for alloc::string::String {
+    fn to_storage_bytes(v: &Self) -> Vec<u8> {
+        v.as_bytes().to_vec()
+    }
+
+    fn from_storage_bytes(b: Vec<u8>) -> Self {
+        alloc::string::String::from_utf8(b).unwrap_or_default()
+    }
+}
+
+impl DynamicValue for Bytes {
+    fn to_storage_bytes(v: &Self) -> Vec<u8> {
+        v.to_vec()
+    }
+
+    fn from_storage_bytes(b: Vec<u8>) -> Self {
+        Bytes::from(b)
+    }
+}
+
+impl<T> StorageStorable for DynamicSlot<T>
+where
+    T: DynamicValue + SolValue + core::convert::From<<<T as SolValue>::SolType as SolType>::RustType>,
+{
+    type Value = T;
+
+    fn __read(base: U256) -> Self::Value {
+        // load length (in bytes) from base slot
+        let len_u256 = sload(base);
+        let limbs = len_u256.as_limbs();
+        if limbs[1] != 0 || limbs[2] != 0 || limbs[3] != 0 {
+            // length too large to fit into usize on this platform
+            revert();
+        }
+        let len = limbs[0] as usize;
+        if len == 0 {
+            return T::from_storage_bytes(Vec::new());
+        }
+
+        // Prevent excessive allocations
+        if len > MAX_DYNAMIC_BYTES {
+            revert();
+        }
+
+        // number of 32-byte words to read
+        let words = (len + 31) / 32;
+        let mut out = Vec::with_capacity(words * 32);
+
+        for i in 0..(words as u64) {
+            // key = keccak256(base || i_be)
+            let base_bytes: [u8; 32] = base.to_be_bytes();
+            let idx_bytes = i.to_be_bytes();
+            let mut buf = Vec::with_capacity(32 + 8);
+            buf.extend_from_slice(&base_bytes);
+            buf.extend_from_slice(&idx_bytes);
+            let key = keccak256(buf.as_ptr() as u64, buf.len() as u64);
+            let word: [u8; 32] = sload(key).to_be_bytes();
+            out.extend_from_slice(&word);
+        }
+
+        out.truncate(len);
+        T::from_storage_bytes(out)
+    }
+
+    fn __write(base: U256, value: Self::Value) {
+        let mut data = T::to_storage_bytes(&value);
+        if data.len() > MAX_DYNAMIC_BYTES {
+            revert();
+        }
+        let len = data.len() as u64;
+
+        // store length at base slot
+        sstore(base, U256::from(len));
+
+        if len == 0 {
+            return;
+        }
+
+        // write 32-byte chunks, padding final chunk with zeros
+        let mut offset = 0usize;
+        let mut index: u64 = 0;
+        while offset < data.len() {
+            let remaining = data.len() - offset;
+            let take = core::cmp::min(32, remaining);
+            let mut chunk = [0u8; 32];
+            chunk[..take].copy_from_slice(&data[offset..offset + take]);
+            // key = keccak256(base || index_be)
+            let base_bytes: [u8; 32] = base.to_be_bytes();
+            let idx_bytes = index.to_be_bytes();
+            let mut buf = Vec::with_capacity(32 + 8);
+            buf.extend_from_slice(&base_bytes);
+            buf.extend_from_slice(&idx_bytes);
+            let key = keccak256(buf.as_ptr() as u64, buf.len() as u64);
+            sstore(key, U256::from_be_bytes(chunk));
+            offset += take;
+            index += 1;
+        }
+    }
+}
+
+impl<T> DirectStorage<T> for DynamicSlot<T>
+where
+    Self: StorageStorable<Value = T>,
+{
+    fn read(&self) -> T {
+        Self::__read(self.id)
+    }
+
+    fn write(&mut self, value: T) {
+        Self::__write(self.id, value)
+    }
+}
+
+

--- a/eth-riscv-runtime/src/types/mod.rs
+++ b/eth-riscv-runtime/src/types/mod.rs
@@ -14,6 +14,17 @@ pub use mapping::Mapping;
 mod slot;
 pub use slot::Slot;
 
+mod dynamic_slot;
+pub use dynamic_slot::DynamicSlot;
+
+/// Dynamic storage semantics (v1):
+/// - Each dynamic field is anchored at a unique base slot `B` (macro-assigned).
+/// - The length (in bytes) is stored at `B`.
+/// - Payload words are stored at `keccak256(B || i_be)` per index `i` (0-based).
+/// - Reads honor the stored length and ignore surplus words.
+/// - For mappings, the base `B` is `keccak256(key || id)`; dynamic payload derives from that base,
+///   ensuring namespaces are disjoint per (contract, field, key, index).
+
 ///  STORAGE TYPES:
 ///  > Must implement the following traits:
 ///     - `StorageLayout`: Allows the `storage` macro to allocate a storage slot.

--- a/eth-riscv-runtime/src/types/mod.rs
+++ b/eth-riscv-runtime/src/types/mod.rs
@@ -15,15 +15,12 @@ mod slot;
 pub use slot::Slot;
 
 mod dynamic_slot;
-pub use dynamic_slot::DynamicSlot;
+pub use dynamic_slot::{DynamicSlot, DynamicValue};
 
-/// Dynamic storage semantics (v1):
-/// - Each dynamic field is anchored at a unique base slot `B` (macro-assigned).
-/// - The length (in bytes) is stored at `B`.
-/// - Payload words are stored at `keccak256(B || i_be)` per index `i` (0-based), where `i_be` is the u64 index encoded as big-endian (8 bytes).
-/// - Reads honor the stored length and ignore surplus words.
-/// - For mappings, the base `B` is `keccak256(key || id)`; dynamic payload derives from that base,
-///   ensuring namespaces are disjoint per (contract, field, key, index).
+/// Dynamic storage (v1):
+/// - Base slot `B` stores byte length; payload word `i` at `keccak256(B || i_be)`, with `i_be` a big-endian u64.
+/// - Under mappings, `B = keccak256(key || id)`.
+/// - Storage layout is internal; ABI remains `SolValue`.
 
 ///  STORAGE TYPES:
 ///  > Must implement the following traits:

--- a/eth-riscv-runtime/src/types/mod.rs
+++ b/eth-riscv-runtime/src/types/mod.rs
@@ -20,7 +20,7 @@ pub use dynamic_slot::DynamicSlot;
 /// Dynamic storage semantics (v1):
 /// - Each dynamic field is anchored at a unique base slot `B` (macro-assigned).
 /// - The length (in bytes) is stored at `B`.
-/// - Payload words are stored at `keccak256(B || i_be)` per index `i` (0-based).
+/// - Payload words are stored at `keccak256(B || i_be)` per index `i` (0-based), where `i_be` is the u64 index encoded as big-endian (8 bytes).
 /// - Reads honor the stored length and ignore surplus words.
 /// - For mappings, the base `B` is `keccak256(key || id)`; dynamic payload derives from that base,
 ///   ensuring namespaces are disjoint per (contract, field, key, index).

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -1,3 +1,22 @@
+//! ERC20 Token Implementation (R55/RISC-V)
+//!
+//! A complete ERC20 token implementation compiled to RISC-V bytecode for execution
+//! in the Hydra EVM. This contract provides standard token functionality with ownership
+//! controls and metadata (name, symbol, decimals).
+//!
+//! ## Features
+//! - Standard ERC20 operations: `transfer`, `approve`, `transferFrom`
+//! - Ownership-based minting with `mint` function
+//! - Token metadata: `name`, `symbol`, `decimals`
+//! - Ownership transfer capability
+//! - Custom error types for clear revert reasons
+//! - Event emission for all state changes
+//!
+//! ## Storage Optimization
+//! - Uses `FixedBytes<32>` for name/symbol (efficient on-chain storage)
+//! - Nested mappings for allowances
+//! - Slot-based storage for all state variables
+
 #![no_std]
 #![no_main]
 
@@ -9,8 +28,14 @@ use eth_riscv_runtime::types::*;
 use alloy_core::primitives::{Address, U256};
 
 extern crate alloc;
+use alloc::string::String;
 
-// -- EVENTS -------------------------------------------------------------------
+// =============================================================================
+// EVENTS
+// =============================================================================
+
+/// Emitted when tokens are transferred between accounts
+/// Minting emits Transfer with `from` = Address::ZERO
 #[derive(Event)]
 pub struct Transfer {
     #[indexed]
@@ -20,6 +45,7 @@ pub struct Transfer {
     pub amount: U256,
 }
 
+/// Emitted when an allowance is set via approve()
 #[derive(Event)]
 pub struct Approval {
     #[indexed]
@@ -29,6 +55,7 @@ pub struct Approval {
     pub amount: U256,
 }
 
+/// Emitted when contract ownership is transferred
 #[derive(Event)]
 pub struct OwnershipTransferred {
     #[indexed]
@@ -37,161 +64,282 @@ pub struct OwnershipTransferred {
     pub to: Address,
 }
 
-// -- ERRORS -------------------------------------------------------------------
+// =============================================================================
+// ERRORS
+// =============================================================================
+
+/// Custom error types for ERC20 operations
+/// These provide clear revert reasons and maintain Solidity ERC20 parity
 #[derive(Error)]
 pub enum ERC20Error {
+    /// Only the contract owner can perform this operation
     OnlyOwner,
+    /// Account has insufficient balance for the transfer
     InsufficientBalance(U256),
+    /// Spender has insufficient allowance for transferFrom
     InsufficientAllowance(U256),
+    /// Cannot approve yourself as spender
     SelfApproval,
+    /// Cannot transfer to yourself
     SelfTransfer,
+    /// Transfer/mint amount must be non-zero
     ZeroAmount,
+    /// Address cannot be zero address
     ZeroAddress,
 }
 
-// -- CONTRACT -----------------------------------------------------------------
+// =============================================================================
+// CONTRACT STATE
+// =============================================================================
+
+/// ERC20 token contract with ownership controls
+/// 
+/// Storage layout uses Slot-based persistence for all state variables.
+/// Dynamic strings for name/symbol are stored via StringSlot with hashed multi-slot backing.
 #[storage]
 pub struct ERC20 {
+    /// Total token supply across all holders
     total_supply: Slot<U256>,
+    /// Mapping from address to token balance
     balance_of: Mapping<Address, Slot<U256>>,
+    /// Nested mapping: owner -> spender -> allowance amount
     allowance_of: Mapping<Address, Mapping<Address, Slot<U256>>>,
+    /// Contract owner (authorized to mint)
     owner: Slot<Address>,
-    // TODO: handle string storage
-    // name: String, 
-    // symbol: String,
-    // decimals: u8,
+    /// Token decimals (typically 18 for standard ERC20)
+    decimals: Slot<U256>,
+    /// Token name
+    name: DynamicSlot<String>,
+    /// Token symbol
+    symbol: DynamicSlot<String>,
 }
+
+// =============================================================================
+// IMPLEMENTATION
+// =============================================================================
 
 #[contract]
 impl ERC20 {
-    // -- CONSTRUCTOR ----------------------------------------------------------
-    pub fn new(owner: Address) -> Self {
-        // Init the contract
+    // -------------------------------------------------------------------------
+    // CONSTRUCTOR
+    // -------------------------------------------------------------------------
+    
+    /// Initializes a new ERC20 token with metadata
+    /// 
+    /// # Arguments
+    /// * `owner` - Address that will own the contract and have minting rights
+    /// * `name` - Human-readable token name (e.g., "Ethereum")
+    /// * `symbol` - Trading symbol (e.g., "ETH")
+    /// * `decimals` - Number of decimal places (typically 18)
+    /// 
+    /// # Returns
+    /// Initialized ERC20 contract instance
+    pub fn new(owner: Address, name: String, symbol: String, decimals: U256) -> Self {
         let mut erc20 = ERC20::default();
 
         // Update state
         erc20.owner.write(owner);
+        erc20.decimals.write(decimals);
 
-        // Return the initialized contract
+        // Store dynamic metadata
+        erc20.name.write(name);
+        erc20.symbol.write(symbol);
+
         erc20
     }
 
-    // -- STATE MODIFYING FUNCTIONS --------------------------------------------
+    // -------------------------------------------------------------------------
+    // STATE-MODIFYING FUNCTIONS
+    // -------------------------------------------------------------------------
+    
+    /// Mints new tokens to a specified address (owner only)
+    /// 
+    /// Increases recipient balance and total supply.
+    /// Emits Transfer event with `from` = Address::ZERO.
+    /// 
+    /// # Arguments
+    /// * `to` - Recipient address
+    /// * `amount` - Tokens to mint
+    /// 
+    /// # Returns
+    /// * `Ok(true)` on success
+    /// * `Err(ERC20Error)` on validation failure
     #[payable]
     pub fn mint(&mut self, to: Address, amount: U256) -> Result<bool, ERC20Error> {
-        // Perform sanity checks
+        // Access control: only owner can mint
         if msg_sender() != self.owner.read() { return Err(ERC20Error::OnlyOwner) }; 
         if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
         if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
 
-        // Increase user balance
+        // Update recipient balance
         let to_balance = self.balance_of[to].read();
         self.balance_of[to].write(to_balance + amount);
 
-        // Increase total supply
+        // Update total supply
         self.total_supply += amount;
         
-        // Emit event + return `true` to stick to (EVM) ERC20 convention
+        // Emit Transfer event (from = 0x0 for mints)
         log::emit(Transfer::new(Address::ZERO, to, amount));
         Ok(true)
     }
 
+    /// Sets spending allowance for a spender
+    /// 
+    /// Allows `spender` to withdraw up to `amount` tokens via transferFrom().
+    /// 
+    /// # Arguments
+    /// * `spender` - Address authorized to spend
+    /// * `amount` - Maximum spendable amount
+    /// 
+    /// # Returns
+    /// * `Ok(true)` on success
+    /// * `Err(ERC20Error)` on validation failure
     pub fn approve(&mut self, spender: Address, amount: U256) -> Result<bool, ERC20Error> {
         let owner = msg_sender();
 
-        // Perform sanity checks
+        // Validation checks
         if spender == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
         if spender == owner { return Err(ERC20Error::SelfApproval) };
 
-        // Update state
+        // Update allowance mapping
         self.allowance_of[owner][spender].write(amount);
 
-        // Emit event + return 
         log::emit(Approval::new(owner, spender, amount));
         Ok(true)
     }
 
+    /// Transfers tokens from caller to another address
+    /// 
+    /// # Arguments
+    /// * `to` - Recipient address
+    /// * `amount` - Tokens to transfer
+    /// 
+    /// # Returns
+    /// * `Ok(true)` on success
+    /// * `Err(ERC20Error)` on validation failure or insufficient balance
     pub fn transfer(&mut self, to: Address, amount: U256) -> Result<bool, ERC20Error> {
         let from = msg_sender();
 
-        // Perform sanity checks
+        // Validation checks
         if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
         if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
         if from == to { return Err(ERC20Error::SelfTransfer) };
 
-        // Read user balances
+        // Load current balances
         let from_balance = self.balance_of[from].read();
         let to_balance = self.balance_of[to].read();
 
-        // Ensure enough balance
+        // Check sufficient balance
         if from_balance < amount { return Err(ERC20Error::InsufficientBalance(from_balance)) }
 
-        // Update state
+        // Update balances atomically
         self.balance_of[from].write(from_balance - amount);
         self.balance_of[to].write(to_balance + amount);
 
-        // Emit event + return 
         log::emit(Transfer::new(from, to, amount));
         Ok(true)
     }
 
+    /// Transfers tokens on behalf of another address using allowance
+    /// 
+    /// Caller must have sufficient allowance from `from` address.
+    /// 
+    /// # Arguments
+    /// * `from` - Token owner (must have approved caller)
+    /// * `to` - Recipient address
+    /// * `amount` - Tokens to transfer
+    /// 
+    /// # Returns
+    /// * `Ok(true)` on success
+    /// * `Err(ERC20Error)` on insufficient allowance or balance
     pub fn transfer_from(&mut self, from: Address, to: Address, amount: U256) -> Result<bool, ERC20Error> {
         let msg_sender = msg_sender();
 
-        // Perform sanity checks
+        // Validation checks
         if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
         if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
         if from == to { return Err(ERC20Error::SelfTransfer) };
 
-        // Ensure enough allowance
+        // Check allowance (caller must be approved by `from`)
         let allowance = self.allowance_of[from][msg_sender].read();
         if allowance < amount { return Err(ERC20Error::InsufficientAllowance(allowance)) };
 
-        // Ensure enough balance
+        // Check balance
         let from_balance = self.balance_of[from].read();
         if from_balance < amount { return Err(ERC20Error::InsufficientBalance(from_balance)) };
 
-        // Update state
+        // Update allowance (decrease by amount spent)
         self.allowance_of[from][msg_sender].write(allowance - amount);
-        self.balance_of[from].write(from_balance - amount);
         
+        // Update balances atomically
+        self.balance_of[from].write(from_balance - amount);
         let to_balance = self.balance_of[to].read();
         self.balance_of[to].write(to_balance + amount);
 
-        // Emit event + return 
         log::emit(Transfer::new(from, to, amount));
         Ok(true)
     }
 
+    /// Transfers contract ownership to a new address (owner only)
+    /// 
+    /// New owner will have minting rights.
+    /// 
+    /// # Arguments
+    /// * `new_owner` - New contract owner
+    /// 
+    /// # Returns
+    /// * `Ok(true)` on success
+    /// * `Err(ERC20Error::OnlyOwner)` if caller is not owner
     pub fn transfer_ownership(&mut self, new_owner: Address) -> Result<bool, ERC20Error> {
         let from = msg_sender();
 
-        // Perform safety check 
+        // Access control + validation
         if from != self.owner.read() { return Err(ERC20Error::OnlyOwner) }; 
         if from == new_owner { return Err(ERC20Error::SelfTransfer) }; 
 
-        // Update state
+        // Update owner
         self.owner.write(new_owner);
 
-        // Emit event + return 
         log::emit(OwnershipTransferred::new(from, new_owner));
         Ok(true)
     }
 
-    // -- READ-ONLY FUNCTIONS --------------------------------------------------
+    // -------------------------------------------------------------------------
+    // VIEW FUNCTIONS
+    // -------------------------------------------------------------------------
+    
+    /// Returns the current contract owner address
     pub fn owner(&self) -> Address {
         self.owner.read()
     }
 
+    /// Returns the total token supply
     pub fn total_supply(&self) -> U256 {
         self.total_supply.read()
     }
 
+    /// Returns the token balance of an address
     pub fn balance_of(&self, owner: Address) -> U256 {
         self.balance_of[owner].read()
     }
 
+    /// Returns the allowance granted by owner to spender
     pub fn allowance(&self, owner: Address, spender: Address) -> U256 {
         self.allowance_of[owner][spender].read()
     }
+
+    /// Returns token decimals (standard is 18)
+    pub fn decimals(&self) -> U256 {
+        self.decimals.read()
+    }
+
+    // -------------------------------------------------------------------------
+    // METADATA (IERC20Metadata)
+    // -------------------------------------------------------------------------
+    
+    /// Returns token name
+    pub fn name(&self) -> String { self.name.read() }
+
+    /// Returns token symbol
+    pub fn symbol(&self) -> String { self.symbol.read() }
 }

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -12,17 +12,17 @@
 //! - Custom error types for clear revert reasons
 //! - Event emission for all state changes
 //!
-//! ## Storage Optimization
-//! - Uses `FixedBytes<32>` for name/symbol (efficient on-chain storage)
+//! ## Storage
+//! - Uses `DynamicSlot<String>` for name/symbol
+//! - Slot-based storage for all fixed-size values
 //! - Nested mappings for allowances
-//! - Slot-based storage for all state variables
 
 #![no_std]
 #![no_main]
 
 use core::default::Default;
 
-use contract_derive::{contract, payable, storage, Event, Error};
+use contract_derive::{contract, storage, Event, Error};
 use eth_riscv_runtime::types::*;
 
 use alloy_core::primitives::{Address, U256};
@@ -94,8 +94,8 @@ pub enum ERC20Error {
 
 /// ERC20 token contract with ownership controls
 /// 
-/// Storage layout uses Slot-based persistence for all state variables.
-/// Dynamic strings for name/symbol are stored via StringSlot with hashed multi-slot backing.
+/// Storage layout uses Slot-based persistence for fixed-size values.
+/// Dynamic strings for name/symbol are stored via DynamicSlot<String>.
 #[storage]
 pub struct ERC20 {
     /// Total token supply across all holders
@@ -164,7 +164,6 @@ impl ERC20 {
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error)` on validation failure
-    #[payable]
     pub fn mint(&mut self, to: Address, amount: U256) -> Result<bool, ERC20Error> {
         // Access control: only owner can mint
         if msg_sender() != self.owner.read() { return Err(ERC20Error::OnlyOwner) }; 


### PR DESCRIPTION
Hi @sam-iamm , opening as a draft PR for now:

Kept the initial implementation for dynamic storage simple. It introduces a minimal/safe dynamic storage primitive for R55: `DynamicSlot<T>`.

This enables storing variable‑length values (`String`, `Bytes`) without truncation. Current `#[storage]` layout only assigns one 32‑byte slot per field. This made `String/bytes` impossible without truncation and broke Hydra equivalence when metadata exceeded 32 bytes.

- New: `DynamicSlot<T>` with v1 semantics (length at base slot `B`, payload words at `keccak256(B || i_be)`)
- Example: `ERC20` now uses `DynamicSlot<String>` for name and symbol
- Only need ABI parity; storage layout doesn’t need to match Solidity

**Design**
- Base slot `B` stores the byte length
- Payload chunks live at `keccak256(B || i_be)`, where `i_be` is the big‑endian `u64` chunk index starting at 0
- Reads reconstruct exactly `len` bytes and ignore surplus words from prior larger writes
- For mappings, `B` is already derived by the guard (`keccak256(key || id)`), so dynamic payload stays isolated per (contract, field, key, index)

```rust
// Usage example
#[storage]
pub struct ERC20 {
    total_supply: Slot<U256>,
    balance_of: Mapping<Address, Slot<U256>>,
    allowance_of: Mapping<Address, Mapping<Address, Slot<U256>>>,
    owner: Slot<Address>,
    decimals: Slot<U256>,
    // Dynamic metadata (bounded by MAX_DYNAMIC_BYTES)
    name: DynamicSlot<String>,
    symbol: DynamicSlot<String>,
}

// Constructor flow (abridged)
pub fn new(owner: Address, name: String, symbol: String, decimals: U256) -> Self {
    let mut erc20 = ERC20::default();
    erc20.owner.write(owner);
    erc20.decimals.write(decimals);
    erc20.name.write(name);
    erc20.symbol.write(symbol);
    erc20
}
```

**Files changed**
- `eth-riscv-runtime/src/types/dynamic_slot.rs`: add `DynamicSlot<T>`, `DynamicValue`, docs, max bound, stack‑buffered hashing
- `eth-riscv-runtime/src/types/mod.rs`: export `DynamicSlot` and `DynamicValue`; add concise v1 semantics
- `examples/erc20/src/lib.rs`: move `name/symbol` to `DynamicSlot<String>`; constructor writes full metadata

**Safety/Compatibility**
- `Slot<T>` unchanged. `#[storage]` unchanged. Developer read/write pattern unchanged (`.read()`, `.write()`); ABI (params/returns) unchanged
- `MAX_DYNAMIC_BYTES` = 128 KiB to bound allocation and loops
- `String` enforces UTF‑8 on read; invalid bytes revert

**Tests**
- Compilation in the R55-fork, then added ERC20-specific tests to this branch in the stack repo: https://github.com/Firewall-eng/stack/compare/develop...michael/dynamic-storage-test

Feedback welcome on this initial approach. Currently supports `String` and `Bytes`. If we agree on this base, arrays and custom structs can be added later by implementing `DynamicValue` with simple self‑framing (count/offsets/payload) without changing the macro or runtime.