### PR TITLE
contract-derive: selector gen add primitive int mappings; clarify selector-only scope

### DIFF
--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -204,6 +204,15 @@ fn generate_method_impl(
 
     let (arg_names, arg_types) = get_arg_props_skip_first(method);
 
+    // ABI encoding policy for calldata construction:
+    // - 0 args: write the 4-byte selector only.
+    // - 1 arg: use `abi_encode()` which encodes a single value, matching Solidity `abi.encode(arg)`.
+    // - >=2 args: use `abi_encode_params()` which encodes multiple top-level params, matching
+    //   Solidity `abi.encode(a,b,...)`. This matters when any nested value is dynamic (e.g. string,
+    //   bytes) because encoding a single tuple vs. multiple params differs in head/tail layout.
+    //
+    // Note: Whether a Rust type can be encoded is governed by `alloy_sol_types::SolValue` impls.
+    // Selector mapping in `rust_type_to_sol_type` does not guarantee encoder support at call sites.
     let calldata = if arg_names.is_empty() {
         quote! {
             let mut complete_calldata = Vec::with_capacity(4);
@@ -454,6 +463,9 @@ pub fn generate_fn_selector(
 }
 
 // Helper function to convert rust types to their solidity equivalent
+// NOTE: This mapping is used for selector generation only (string signatures -> keccak4).
+// Encoder/decoder support is governed by `alloy_sol_types::SolValue` impls at call sites; adding
+// a type here does not imply that `abi_encode`/`abi_encode_params` is available for that Rust type.
 // TODO: make sure that the impl is robust, so far only tested with "simple types"
 pub fn rust_type_to_sol_type(ty: &Type) -> Result<DynSolType, &'static str> {
     match ty {
@@ -470,6 +482,18 @@ pub fn rust_type_to_sol_type(ty: &Type) -> Result<DynSolType, &'static str> {
                 "bool" | "Bool" => Ok(DynSolType::Bool),
                 "String" | "str" => Ok(DynSolType::String),
                 "Bytes" => Ok(DynSolType::Bytes),
+                // Primitive unsigned integers
+                "u8" => Ok(DynSolType::Uint(8)),
+                "u16" => Ok(DynSolType::Uint(16)),
+                "u32" => Ok(DynSolType::Uint(32)),
+                "u64" => Ok(DynSolType::Uint(64)),
+                "u128" => Ok(DynSolType::Uint(128)),
+                // Primitive signed integers
+                "i8" => Ok(DynSolType::Int(8)),
+                "i16" => Ok(DynSolType::Int(16)),
+                "i32" => Ok(DynSolType::Int(32)),
+                "i64" => Ok(DynSolType::Int(64)),
+                "i128" => Ok(DynSolType::Int(128)),
                 // Fixed-size bytes
                 b if b.starts_with('B') => {
                     let size: usize = b
@@ -713,6 +737,20 @@ mod tests {
         // Invalid cases
         assert!(rust_type_to_sol_type(&parse_quote!(B0)).is_err());
         assert!(rust_type_to_sol_type(&parse_quote!(B33)).is_err());
+    }
+
+    #[test]
+    fn test_rust_to_sol_lower_primitives() {
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(u8)).unwrap(), DynSolType::Uint(8));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(u16)).unwrap(), DynSolType::Uint(16));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(u32)).unwrap(), DynSolType::Uint(32));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(u64)).unwrap(), DynSolType::Uint(64));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(u128)).unwrap(), DynSolType::Uint(128));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(i8)).unwrap(), DynSolType::Int(8));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(i16)).unwrap(), DynSolType::Int(16));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(i32)).unwrap(), DynSolType::Int(32));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(i64)).unwrap(), DynSolType::Int(64));
+        assert_eq!(rust_type_to_sol_type(&parse_quote!(i128)).unwrap(), DynSolType::Int(128));
     }
 
     #[test]


### PR DESCRIPTION
Hi @sam-iamm , this PR adds a small fix to `r55/contract-derive/src/helpers.rs` and aims to address: https://github.com/Firewall-eng/stack/issues/555

**Problem**
- Selector generation failed for functions whose signatures used Rust primitives `u8/u16/u32/u64/u128` or `i8/i16/i32/i64/i128`
- Root cause: `rust_type_to_sol_type` did not map these primitives, so `generate_fn_selector` returned `None` and tripped the “Unable to generate fn selector” expect

**Fix**
- Add primitive integer mappings and document selector-only intent (signature → keccak4; not ABI encode/decode).
```rust
r55/contract-derive/src/helpers.rs
// selector generation only (string signatures -> keccak4). Not ABI encode/decode
pub fn rust_type_to_sol_type(ty: &Type) -> Result<DynSolType, &'static str> {
    match ty {
        Type::Path(type_path) => {
            let path = &type_path.path;
            let segment = path.segments.last().ok_or("Empty type path")?;
            let ident = &segment.ident;
            let type_name = ident.to_string();

            match type_name.as_str() {
                // Fixed-size types
                "Address" => Ok(DynSolType::Address),
                "Function" => Ok(DynSolType::Function),
                "bool" | "Bool" => Ok(DynSolType::Bool),
                "String" | "str" => Ok(DynSolType::String),
                "Bytes" => Ok(DynSolType::Bytes),
                // Primitive unsigned integers -> Added these
                "u8" => Ok(DynSolType::Uint(8)),
                "u16" => Ok(DynSolType::Uint(16)),
                "u32" => Ok(DynSolType::Uint(32)),
                "u64" => Ok(DynSolType::Uint(64)),
                "u128" => Ok(DynSolType::Uint(128)),
                // Primitive signed integers -> Added these
                "i8" => Ok(DynSolType::Int(8)),
                "i16" => Ok(DynSolType::Int(16)),
                "i32" => Ok(DynSolType::Int(32)),
                "i64" => Ok(DynSolType::Int(64)),
                "i128" => Ok(DynSolType::Int(128)),
                // Fixed-size bytes
                b if b.starts_with('B') => {
                ......
```

**Scope**
- Single-file change: `r55/contract-derive/src/helpers.rs`. Only affects selector strings. No runtime/interface behavior changes

**Example (Context)**
In `stack/contracts/src/shared/ERC20Bridge.sol`, we have:

```
    struct TokenDescription {
        // The source token address on the source chain
        address sourceToken;
        // The token name
        string name;
        // The token symbol
        string symbol;
        // The token decimals
        uint8 decimals;
    }

    /// @inheritdoc IERC20Bridge
    function getTokenDescriptionId(TokenDescription memory tokenDesc) public pure returns (bytes32 id) {
        return _generateTokenDescriptionId(tokenDesc);
    }
```

When testing n = 1 and n = 2 parity in Hydra, the struct is defined as:

```
test_erc20_bridge
pub struct TokenDescription {
    pub sourceToken: Address,
    pub name: String,
    pub symbol: String,
    pub decimals: u8, // Rust primitive
}
```

- With this PR, selectors for signatures involving u8/int8 are generated correctly. ABI encoding remains governed by Alloy SolValue implementors


**Notes**
- Alloy 1.3.1: `SolValue<u8>` is not implemented; `SolValue<i8>` is
- I had to change `TokenDescription` in `IERC20Bridge` to use an `int8` for `decimals` rather than a `uint8`, alloy documentation attached below

**References**
- Issue: https://github.com/Firewall-eng/stack/issues/555
- Solidity ABI: https://docs.soliditylang.org/en/v0.8.25/abi-spec.html
- Alloy SolValue (v1.3.1): https://docs.rs/alloy-sol-types/1.3.1/alloy_sol_types/trait.SolValue.html
- DynSolType (v1.3.1): https://docs.rs/alloy-dyn-abi/1.3.1/alloy_dyn_abi/enum.DynSolType.html