### PR TITLE
feat: special handle uint8 for abi encode/decode

### DIFF
--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use alloy_core::primitives::keccak256;
 use alloy_dyn_abi::DynSolType;
 use proc_macro2::TokenStream;
@@ -223,24 +221,13 @@ fn generate_method_impl(
             ]);
         }
     } else if arg_names.len() == 1 {
-        // Single-argument: encode, converting u8 -> U256 for ABI compatibility
+        // Single-argument: use abi_encode() with nested u8→U256 upcasting
         {
-            // Prepare converted arg binding name
-            let enc_ident = format_ident!("__arg{}_enc", 0usize);
-            // Determine if the sole arg is u8
-            let is_u8 = matches!(arg_types[0], syn::Type::Path(ref tp) if tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false));
-
-            let enc_let = if is_u8 {
-                let name0 = &arg_names[0];
-                quote! { let #enc_ident = alloy_core::primitives::U256::from(#name0 as u64); }
-            } else {
-                let name0 = &arg_names[0];
-                quote! { let #enc_ident = #name0; }
-            };
-
+            let name0 = &arg_names[0];
+            let ty0 = arg_types[0];
+            let enc_expr = gen_upcast_expr(quote! { #name0 }, ty0);
             quote! {
-                #enc_let
-                let mut args_calldata = (#enc_ident,).abi_encode();
+                let mut args_calldata = (#enc_expr,).abi_encode();
                 let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
                 complete_calldata.extend_from_slice(&[
                     #method_selector.to_be_bytes()[0],
@@ -252,24 +239,13 @@ fn generate_method_impl(
             }
         }
     } else {
-        // Multi-argument: encode as standard Solidity params (abi.encode(a,b,...))
-        // Convert any u8 args to U256 prior to encoding to satisfy SolValue bounds
+        // Multi-argument: encode as standard Solidity params (abi.encode(a,b,...)) with nested u8→U256 upcasting
         {
-            // Build per-arg converted bindings
-            let enc_idents: Vec<_> = (0..arg_names.len()).map(|i| format_ident!("__arg{}_enc", i)).collect();
-            let enc_lets: Vec<_> = arg_names.iter().zip(arg_types.iter()).enumerate().map(|(i, (name, ty))| {
-                let enc_ident = &enc_idents[i];
-                let is_u8 = matches!(ty, syn::Type::Path(ref tp) if tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false));
-                if is_u8 {
-                    quote! { let #enc_ident = alloy_core::primitives::U256::from(#name as u64); }
-                } else {
-                    quote! { let #enc_ident = #name; }
-                }
-            }).collect();
-
+            let enc_exprs: Vec<_> = arg_names.iter().zip(arg_types.iter())
+                .map(|(name, ty)| gen_upcast_expr(quote! { #name }, ty))
+                .collect();
             quote! {
-                #(#enc_lets)*
-                let mut args_calldata = (#(#enc_idents),*).abi_encode_params();
+                let mut args_calldata = (#( #enc_exprs ),*).abi_encode_params();
                 let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
                 complete_calldata.extend_from_slice(&[
                     #method_selector.to_be_bytes()[0],
@@ -305,7 +281,28 @@ fn generate_method_impl(
     // Reference: https://github.com/sam-iamm/r55/pull/9
     match extract_wrapper_types(&method.return_type) {
         // If `Result<T, E>` handle each individual type
-        WrapperType::Result(ok_type, err_type) => quote! {
+        WrapperType::Result(ok_type, err_type) => {
+            let ok_decode_block = {
+                let ok_syn = extract_result_ok_type_syn(&method.return_type).expect("ok type");
+                if type_needs_u8_upcast(ok_syn) {
+                    let up_ty = upcast_type_tokens(ok_syn);
+                    let down_expr = gen_downcast_expr(quote! { __dec_ok }, ok_syn);
+                    quote! {
+                        match <#up_ty>::abi_decode(&bytes) {
+                            Ok(__dec_ok) => Ok(#down_expr),
+                            Err(_) => Err(<#err_type>::abi_decode(&bytes, true))
+                        }
+                    }
+                } else {
+                    quote! {
+                        match <#ok_type>::abi_decode(&bytes) {
+                            Ok(decoded) => Ok(decoded),
+                            Err(_) => Err(<#err_type>::abi_decode(&bytes, true))
+                        }
+                    }
+                }
+            };
+            quote! {
             pub fn #name(#self_param, #(#arg_names: #arg_types),*) -> Result<#ok_type, #err_type>  {
                 use alloy_sol_types::SolValue;
                 use alloc::vec::Vec;
@@ -321,50 +318,34 @@ fn generate_method_impl(
 
                 match result {
                     // Call succeeded - decode return data
-                    Ok(bytes) => match <#ok_type>::abi_decode(&bytes) {
-                        Ok(decoded) => Ok(decoded),
-                        Err(_) => Err(<#err_type>::abi_decode(&bytes, true))
-                    },
+                    Ok(bytes) => { #ok_decode_block },
                     // Call reverted - return error (no auto-revert, user handles Result)
                     Err(revert_data) => Err(<#err_type>::abi_decode(&revert_data, true))
                 }
             }
+        }
         },
         // If `Option<T>` unwrap the type to decode, and wrap it back
         WrapperType::Option(return_ty) => {
-            quote! {
-                pub fn #name(#self_param, #(#arg_names: #arg_types),*) -> Option<#return_ty> {
-                    use alloy_sol_types::SolValue;
-                    use alloc::vec::Vec;
-
-                    #calldata
-
-                    let result = #call_fn(
-                        self.address,
-                        0_u64,
-                        &complete_calldata,
-                        None
-                    );
-
-                    match result {
-                        // Call succeeded - decode and return
-                        Ok(bytes) => match <#return_ty>::abi_decode(&bytes) {
+            let opt_decode_block = {
+                let inner_syn = extract_option_inner_type_syn(&method.return_type).expect("inner type");
+                if type_needs_u8_upcast(inner_syn) {
+                    let up_ty = upcast_type_tokens(inner_syn);
+                    let down_expr = gen_downcast_expr(quote! { __dec_ok }, inner_syn);
+                    quote! {
+                        match <#up_ty>::abi_decode(&bytes) {
+                            Ok(__dec_ok) => Some(#down_expr),
+                            Err(_) => None
+                        }
+                    }
+                } else {
+                    quote! {
+                        match <#return_ty>::abi_decode(&bytes) {
                             Ok(decoded) => Some(decoded),
                             Err(_) => None
-                        },
-                        // Call reverted - auto-propagate (if A→B reverts, A reverts)
-                        Err(revert_data) => {
-                            eth_riscv_runtime::revert_with_error(&revert_data);
                         }
                     }
                 }
-            }
-        }
-        // Otherwise, simply decode the value + wrap it in an `Option` to force error-handling
-        WrapperType::None => {
-            let return_ty = match return_type {
-                ReturnType::Default => quote! { () },
-                ReturnType::Type(_, ty) => quote! { #ty },
             };
             quote! {
                 pub fn #name(#self_param, #(#arg_names: #arg_types),*) -> Option<#return_ty> {
@@ -382,10 +363,65 @@ fn generate_method_impl(
 
                     match result {
                         // Call succeeded - decode and return
-                        Ok(bytes) => match <#return_ty>::abi_decode(&bytes) {
-                            Ok(decoded) => Some(decoded),
-                            Err(_) => None
-                        },
+                        Ok(bytes) => { #opt_decode_block },
+                        // Call reverted - auto-propagate (if A→B reverts, A reverts)
+                        Err(revert_data) => {
+                            eth_riscv_runtime::revert_with_error(&revert_data);
+                        }
+                    }
+                }
+            }
+        }
+        // Otherwise, simply decode the value + wrap it in an `Option` to force error-handling
+        WrapperType::None => {
+            let return_ty = match return_type {
+                ReturnType::Default => quote! { () },
+                ReturnType::Type(_, ty) => quote! { #ty },
+            };
+            let none_decode_block = {
+                let inner_syn_opt: Option<&Type> = match &method.return_type {
+                    ReturnType::Type(_, ty) => Some(ty.as_ref()),
+                    ReturnType::Default => None,
+                };
+                if let Some(inner_syn) = inner_syn_opt {
+                    if type_needs_u8_upcast(inner_syn) {
+                        let up_ty = upcast_type_tokens(inner_syn);
+                        let down_expr = gen_downcast_expr(quote! { __dec_ok }, inner_syn);
+                        quote! {
+                            match <#up_ty>::abi_decode(&bytes) {
+                                Ok(__dec_ok) => Some(#down_expr),
+                                Err(_) => None
+                            }
+                        }
+                    } else {
+                        quote! {
+                            match <#return_ty>::abi_decode(&bytes) {
+                                Ok(decoded) => Some(decoded),
+                                Err(_) => None
+                            }
+                        }
+                    }
+                } else {
+                    quote! { Some(()) }
+                }
+            };
+            quote! {
+                pub fn #name(#self_param, #(#arg_names: #arg_types),*) -> Option<#return_ty> {
+                    use alloy_sol_types::SolValue;
+                    use alloc::vec::Vec;
+
+                    #calldata
+
+                    let result = #call_fn(
+                        self.address,
+                        0_u64,
+                        &complete_calldata,
+                        None
+                    );
+
+                    match result {
+                        // Call succeeded - decode and return
+                        Ok(bytes) => { #none_decode_block },
                         // Call reverted - auto-propagate
                         Err(revert_data) => {
                             eth_riscv_runtime::revert_with_error(&revert_data);
@@ -461,6 +497,228 @@ pub fn extract_wrapper_types(return_type: &ReturnType) -> WrapperType {
             WrapperType::Option(inner_type)
         }
         _ => WrapperType::None,
+    }
+}
+
+// Return true if the success value (direct return, Option<T>, or Result<T, E>) is u8
+pub fn return_success_is_u8(return_type: &ReturnType) -> bool {
+    match return_type {
+        ReturnType::Default => false,
+        ReturnType::Type(_, ty) => match ty.as_ref() {
+            Type::Path(type_path) => {
+                if let Some(last) = type_path.path.segments.last() {
+                    match last.ident.to_string().as_str() {
+                        "Option" => {
+                            if let PathArguments::AngleBracketed(args) = &last.arguments {
+                                if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
+                                    if let Type::Path(p) = inner_ty {
+                                        return p.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false);
+                                    }
+                                }
+                            }
+                            false
+                        }
+                        "Result" => {
+                            if let PathArguments::AngleBracketed(args) = &last.arguments {
+                                let mut iter = args.args.iter();
+                                if let Some(syn::GenericArgument::Type(ok_ty)) = iter.next() {
+                                    if let Type::Path(p) = ok_ty {
+                                        return p.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false);
+                                    }
+                                }
+                            }
+                            false
+                        }
+                        _ => last.ident == "u8",
+                    }
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        },
+    }
+}
+
+// Extract syn type of Result<Ok, Err>'s Ok type
+pub fn extract_result_ok_type_syn(return_type: &ReturnType) -> Option<&Type> {
+    match return_type {
+        ReturnType::Type(_, ty) => match ty.as_ref() {
+            Type::Path(type_path) => type_path.path.segments.last().and_then(|seg| {
+                if seg.ident == "Result" {
+                    if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                        if let Some(syn::GenericArgument::Type(ok_ty)) = args.args.first() {
+                            return Some(ok_ty);
+                        }
+                    }
+                }
+                None
+            }),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+// Extract syn type of Option<T>'s T
+pub fn extract_option_inner_type_syn(return_type: &ReturnType) -> Option<&Type> {
+    match return_type {
+        ReturnType::Type(_, ty) => match ty.as_ref() {
+            Type::Path(type_path) => type_path.path.segments.last().and_then(|seg| {
+                if seg.ident == "Option" {
+                    if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                        if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
+                            return Some(inner_ty);
+                        }
+                    }
+                }
+                None
+            }),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+// Recursively determine if a type contains any u8 that needs upcasting
+pub fn type_needs_u8_upcast(ty: &Type) -> bool {
+    match ty {
+        Type::Path(tp) => tp
+            .path
+            .segments
+            .last()
+            .map(|s| {
+                if s.ident == "u8" {
+                    true
+                } else if s.ident == "Vec" {
+                    if let PathArguments::AngleBracketed(args) = &s.arguments {
+                        if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                            type_needs_u8_upcast(inner)
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(false),
+        Type::Tuple(t) => t.elems.iter().any(type_needs_u8_upcast),
+        Type::Array(a) => type_needs_u8_upcast(&a.elem),
+        _ => false,
+    }
+}
+
+// Build a type TokenStream where all u8 occurrences are replaced by U256 recursively
+pub fn upcast_type_tokens(ty: &Type) -> TokenStream {
+    match ty {
+        Type::Path(tp) => {
+            let seg = tp.path.segments.last().unwrap();
+            if seg.ident == "u8" {
+                quote! { alloy_core::primitives::U256 }
+            } else if seg.ident == "Vec" {
+                if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        let inner_up = upcast_type_tokens(inner);
+                        quote! { alloc::vec::Vec<#inner_up> }
+                    } else {
+                        quote! { #ty }
+                    }
+                } else {
+                    quote! { #ty }
+                }
+            } else {
+                quote! { #ty }
+            }
+        }
+        Type::Tuple(t) => {
+            let elems = t.elems.iter().map(upcast_type_tokens);
+            quote! { ( #( #elems ),* ) }
+        }
+        Type::Array(a) => {
+            let inner = upcast_type_tokens(&a.elem);
+            let len = &a.len;
+            quote! { [#inner; #len] }
+        }
+        _ => quote! { #ty },
+    }
+}
+
+// Generate an expression converting a value to its upcasted form recursively
+pub fn gen_upcast_expr(var: TokenStream, ty: &Type) -> TokenStream {
+    match ty {
+        Type::Path(tp) => {
+            let seg = tp.path.segments.last().unwrap();
+            if seg.ident == "u8" {
+                quote! { alloy_core::primitives::U256::from(#var as u64) }
+            } else if seg.ident == "Vec" {
+                if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        let inner_conv = gen_upcast_expr(quote! { __el }, inner);
+                        quote! { #var.into_iter().map(|__el| { #inner_conv }).collect::<alloc::vec::Vec<_>>() }
+                    } else {
+                        quote! { #var }
+                    }
+                } else {
+                    quote! { #var }
+                }
+            } else {
+                quote! { #var }
+            }
+        }
+        Type::Tuple(t) => {
+            let elems = t
+                .elems
+                .iter()
+                .enumerate()
+                .map(|(i, ty_i)| gen_upcast_expr(quote! { #var.#i }, ty_i));
+            quote! { ( #( #elems ),* ) }
+        }
+        Type::Array(a) => {
+            let inner_conv = gen_upcast_expr(quote! { __el }, &a.elem);
+            quote! { core::array::from_fn(|__i| { let __el = #var[__i].clone(); #inner_conv }) }
+        }
+        _ => quote! { #var },
+    }
+}
+
+// Generate an expression converting an upcasted value back to its original type recursively
+pub fn gen_downcast_expr(var: TokenStream, ty: &Type) -> TokenStream {
+    match ty {
+        Type::Path(tp) => {
+            let seg = tp.path.segments.last().unwrap();
+            if seg.ident == "u8" {
+                quote! { (#var.as_limbs()[0] as u8) }
+            } else if seg.ident == "Vec" {
+                if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        let inner_conv = gen_downcast_expr(quote! { __el }, inner);
+                        quote! { #var.into_iter().map(|__el| { #inner_conv }).collect::<alloc::vec::Vec<_>>() }
+                    } else {
+                        quote! { #var }
+                    }
+                } else {
+                    quote! { #var }
+                }
+            } else {
+                quote! { #var }
+            }
+        }
+        Type::Tuple(t) => {
+            let elems = t
+                .elems
+                .iter()
+                .enumerate()
+                .map(|(i, ty_i)| gen_downcast_expr(quote! { #var.#i }, ty_i));
+            quote! { ( #( #elems ),* ) }
+        }
+        Type::Array(a) => {
+            let inner_conv = gen_downcast_expr(quote! { __el }, &a.elem);
+            quote! { core::array::from_fn(|__i| { let __el = #var[__i].clone(); #inner_conv }) }
+        }
+        _ => quote! { #var },
     }
 }
 
@@ -658,13 +916,6 @@ pub fn generate_deployment_code(
             let method_info = MethodInfo::from(method);
             let (arg_names, arg_types) = get_arg_props_all(&method_info);
 
-            // Flags for which args are u8
-            let is_u8_flags: Vec<bool> = arg_types.iter().map(|ty| {
-                if let syn::Type::Path(tp) = ty {
-                    tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false)
-                } else { false }
-            }).collect();
-
             let decode_and_init = match arg_types.len() {
                 0 => {
                     quote! {
@@ -674,14 +925,16 @@ pub fn generate_deployment_code(
                 1 => {
                     let ty0 = arg_types[0];
                     let name0 = &arg_names[0];
-                    let is_u8 = is_u8_flags[0];
-                    if is_u8 {
+                    let needs = type_needs_u8_upcast(ty0);
+                    let up_ty = upcast_type_tokens(ty0);
+                    let down_expr = gen_downcast_expr(quote! { __dec0 }, ty0);
+                    if needs {
                         quote! {
                             // Get encoded constructor args
                             let calldata = eth_riscv_runtime::msg_data();
-                            let __dec0 = <alloy_core::primitives::U256>::abi_decode(&calldata)
+                            let __dec0 = <#up_ty>::abi_decode(&calldata)
                                 .expect("Failed to decode constructor args");
-                            let #name0: u8 = __dec0.as_limbs()[0] as u8;
+                            let #name0 = #down_expr;
                             #struct_name::new(#name0);
                         }
                     } else {
@@ -696,15 +949,14 @@ pub fn generate_deployment_code(
                 }
                 _ => {
                     // Build decode as tuple of possibly-upcast types
-                    let dec_types: Vec<proc_macro2::TokenStream> = arg_types.iter().zip(is_u8_flags.iter())
-                        .map(|(ty, is_u8)| if *is_u8 { quote! { alloy_core::primitives::U256 } } else { quote! { #ty } })
+                    let dec_types: Vec<proc_macro2::TokenStream> = arg_types.iter()
+                        .map(|ty| upcast_type_tokens(ty))
                         .collect();
                     let dec_names: Vec<proc_macro2::Ident> = (0..arg_names.len()).map(|i| format_ident!("__ctor_arg{}_dec", i)).collect();
-                    let cast_binds: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(dec_names.iter()).zip(is_u8_flags.iter())
-                        .map(|((name, dec), is_u8)| if *is_u8 {
-                            quote! { let #name: u8 = #dec.as_limbs()[0] as u8; }
-                        } else {
-                            quote! { let #name = #dec; }
+                    let cast_binds: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(dec_names.iter()).zip(arg_types.iter())
+                        .map(|((name, dec), ty)| {
+                            let down_expr = gen_downcast_expr(quote! { #dec }, ty);
+                            quote! { let #name = #down_expr; }
                         }).collect();
 
                     quote! {

--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -500,46 +500,6 @@ pub fn extract_wrapper_types(return_type: &ReturnType) -> WrapperType {
     }
 }
 
-// Return true if the success value (direct return, Option<T>, or Result<T, E>) is u8
-pub fn return_success_is_u8(return_type: &ReturnType) -> bool {
-    match return_type {
-        ReturnType::Default => false,
-        ReturnType::Type(_, ty) => match ty.as_ref() {
-            Type::Path(type_path) => {
-                if let Some(last) = type_path.path.segments.last() {
-                    match last.ident.to_string().as_str() {
-                        "Option" => {
-                            if let PathArguments::AngleBracketed(args) = &last.arguments {
-                                if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
-                                    if let Type::Path(p) = inner_ty {
-                                        return p.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false);
-                                    }
-                                }
-                            }
-                            false
-                        }
-                        "Result" => {
-                            if let PathArguments::AngleBracketed(args) = &last.arguments {
-                                let mut iter = args.args.iter();
-                                if let Some(syn::GenericArgument::Type(ok_ty)) = iter.next() {
-                                    if let Type::Path(p) = ok_ty {
-                                        return p.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false);
-                                    }
-                                }
-                            }
-                            false
-                        }
-                        _ => last.ident == "u8",
-                    }
-                } else {
-                    false
-                }
-            }
-            _ => false,
-        },
-    }
-}
-
 // Extract syn type of Result<Ok, Err>'s Ok type
 pub fn extract_result_ok_type_syn(return_type: &ReturnType) -> Option<&Type> {
     match return_type {

--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -658,6 +658,13 @@ pub fn generate_deployment_code(
             let method_info = MethodInfo::from(method);
             let (arg_names, arg_types) = get_arg_props_all(&method_info);
 
+            // Flags for which args are u8
+            let is_u8_flags: Vec<bool> = arg_types.iter().map(|ty| {
+                if let syn::Type::Path(tp) = ty {
+                    tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false)
+                } else { false }
+            }).collect();
+
             let decode_and_init = match arg_types.len() {
                 0 => {
                     quote! {
@@ -667,20 +674,45 @@ pub fn generate_deployment_code(
                 1 => {
                     let ty0 = arg_types[0];
                     let name0 = &arg_names[0];
-                    quote! {
-                        // Get encoded constructor args
-                        let calldata = eth_riscv_runtime::msg_data();
-                        let #name0 = <#ty0>::abi_decode(&calldata)
-                            .expect("Failed to decode constructor args");
-                        #struct_name::new(#name0);
+                    let is_u8 = is_u8_flags[0];
+                    if is_u8 {
+                        quote! {
+                            // Get encoded constructor args
+                            let calldata = eth_riscv_runtime::msg_data();
+                            let __dec0 = <alloy_core::primitives::U256>::abi_decode(&calldata)
+                                .expect("Failed to decode constructor args");
+                            let #name0: u8 = __dec0.as_limbs()[0] as u8;
+                            #struct_name::new(#name0);
+                        }
+                    } else {
+                        quote! {
+                            // Get encoded constructor args
+                            let calldata = eth_riscv_runtime::msg_data();
+                            let #name0 = <#ty0>::abi_decode(&calldata)
+                                .expect("Failed to decode constructor args");
+                            #struct_name::new(#name0);
+                        }
                     }
                 }
                 _ => {
+                    // Build decode as tuple of possibly-upcast types
+                    let dec_types: Vec<proc_macro2::TokenStream> = arg_types.iter().zip(is_u8_flags.iter())
+                        .map(|(ty, is_u8)| if *is_u8 { quote! { alloy_core::primitives::U256 } } else { quote! { #ty } })
+                        .collect();
+                    let dec_names: Vec<proc_macro2::Ident> = (0..arg_names.len()).map(|i| format_ident!("__ctor_arg{}_dec", i)).collect();
+                    let cast_binds: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(dec_names.iter()).zip(is_u8_flags.iter())
+                        .map(|((name, dec), is_u8)| if *is_u8 {
+                            quote! { let #name: u8 = #dec.as_limbs()[0] as u8; }
+                        } else {
+                            quote! { let #name = #dec; }
+                        }).collect();
+
                     quote! {
                         // Get encoded constructor args
                         let calldata = eth_riscv_runtime::msg_data();
-                        let (#(#arg_names),*) = <(#(#arg_types),*)>::abi_decode_params_validate(&calldata)
+                        let (#( #dec_names ),*) = <(#( #dec_types ),*)>::abi_decode_params_validate(&calldata)
                             .expect("Failed to decode constructor args");
+                        #(#cast_binds)*
                         #struct_name::new(#(#arg_names),*);
                     }
                 }

--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -223,30 +223,62 @@ fn generate_method_impl(
             ]);
         }
     } else if arg_names.len() == 1 {
-        // Single-argument: use abi_encode() (equivalent to abi.encode(arg))
-        quote! {
-            let mut args_calldata = (#(#arg_names),*).abi_encode();
-            let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
-            complete_calldata.extend_from_slice(&[
-                #method_selector.to_be_bytes()[0],
-                #method_selector.to_be_bytes()[1],
-                #method_selector.to_be_bytes()[2],
-                #method_selector.to_be_bytes()[3],
-            ]);
-            complete_calldata.append(&mut args_calldata);
+        // Single-argument: encode, converting u8 -> U256 for ABI compatibility
+        {
+            // Prepare converted arg binding name
+            let enc_ident = format_ident!("__arg{}_enc", 0usize);
+            // Determine if the sole arg is u8
+            let is_u8 = matches!(arg_types[0], syn::Type::Path(ref tp) if tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false));
+
+            let enc_let = if is_u8 {
+                let name0 = &arg_names[0];
+                quote! { let #enc_ident = alloy_core::primitives::U256::from(#name0 as u64); }
+            } else {
+                let name0 = &arg_names[0];
+                quote! { let #enc_ident = #name0; }
+            };
+
+            quote! {
+                #enc_let
+                let mut args_calldata = (#enc_ident,).abi_encode();
+                let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
+                complete_calldata.extend_from_slice(&[
+                    #method_selector.to_be_bytes()[0],
+                    #method_selector.to_be_bytes()[1],
+                    #method_selector.to_be_bytes()[2],
+                    #method_selector.to_be_bytes()[3],
+                ]);
+                complete_calldata.append(&mut args_calldata);
+            }
         }
     } else {
         // Multi-argument: encode as standard Solidity params (abi.encode(a,b,...))
-        quote! {
-            let mut args_calldata = (#(#arg_names),*).abi_encode_params();
-            let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
-            complete_calldata.extend_from_slice(&[
-                #method_selector.to_be_bytes()[0],
-                #method_selector.to_be_bytes()[1],
-                #method_selector.to_be_bytes()[2],
-                #method_selector.to_be_bytes()[3],
-            ]);
-            complete_calldata.append(&mut args_calldata);
+        // Convert any u8 args to U256 prior to encoding to satisfy SolValue bounds
+        {
+            // Build per-arg converted bindings
+            let enc_idents: Vec<_> = (0..arg_names.len()).map(|i| format_ident!("__arg{}_enc", i)).collect();
+            let enc_lets: Vec<_> = arg_names.iter().zip(arg_types.iter()).enumerate().map(|(i, (name, ty))| {
+                let enc_ident = &enc_idents[i];
+                let is_u8 = matches!(ty, syn::Type::Path(ref tp) if tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false));
+                if is_u8 {
+                    quote! { let #enc_ident = alloy_core::primitives::U256::from(#name as u64); }
+                } else {
+                    quote! { let #enc_ident = #name; }
+                }
+            }).collect();
+
+            quote! {
+                #(#enc_lets)*
+                let mut args_calldata = (#(#enc_idents),*).abi_encode_params();
+                let mut complete_calldata = Vec::with_capacity(4 + args_calldata.len());
+                complete_calldata.extend_from_slice(&[
+                    #method_selector.to_be_bytes()[0],
+                    #method_selector.to_be_bytes()[1],
+                    #method_selector.to_be_bytes()[2],
+                    #method_selector.to_be_bytes()[3],
+                ]);
+                complete_calldata.append(&mut args_calldata);
+            }
         }
     };
 

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -300,6 +300,22 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 .expect("Unable to generate fn selector")
         );
         let (arg_names, arg_types) = helpers::get_arg_props_skip_first(&method_info);
+        // For ABI decode: replace u8 params with U256, then cast back to u8 before call
+        let is_u8_flags: Vec<bool> = arg_types.iter().map(|ty| {
+            if let syn::Type::Path(tp) = ty {
+                tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false)
+            } else { false }
+        }).collect();
+        let dec_types: Vec<proc_macro2::TokenStream> = arg_types.iter().zip(is_u8_flags.iter())
+            .map(|(ty, is_u8)| if *is_u8 { quote! { alloy_core::primitives::U256 } } else { quote! { #ty } })
+            .collect();
+        let dec_names: Vec<proc_macro2::Ident> = (0..arg_names.len()).map(|i| format_ident!("__arg{}_dec", i)).collect();
+        let cast_binds: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(dec_names.iter()).zip(is_u8_flags.iter())
+            .map(|((name, dec), is_u8)| if *is_u8 {
+                quote! { let #name: u8 = #dec.as_limbs()[0] as u8; }
+            } else {
+                quote! { let #name = #dec; }
+            }).collect();
 
         // Check if there are payable methods
         let checks = if !is_payable(&method) {
@@ -358,7 +374,8 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         quote! {
             #method_selector => {
-                let (#( #arg_names, )*) = <(#( #arg_types,)*)>::abi_decode_params_validate(&calldata).expect("abi decode failed");
+                let (#( #dec_names, )*) = <(#( #dec_types ,)*)>::abi_decode_params_validate(&calldata).expect("abi decode failed");
+                #(#cast_binds)*
                 #checks
                 #return_handling
             }

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -62,8 +62,37 @@ pub fn error_derive(input: TokenStream) -> TokenStream {
         let data = match &variant.fields {
             Fields::Unit => quote! {},
             Fields::Unnamed(fields) => {
-                let vars = (0..fields.unnamed.len()).map(|i| format_ident!("_{}", i));
-                quote! { #( res.extend_from_slice(&#vars.abi_encode()); )* }
+                let _vars: Vec<_> = (0..fields.unnamed.len()).map(|i| format_ident!("_{}", i)).collect();
+                let enc_stmts: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(i, f)| {
+                        let var_ident = format_ident!("_{}", i);
+                        let is_u8 = if let syn::Type::Path(tp) = &f.ty {
+                            tp.path
+                                .segments
+                                .last()
+                                .map(|s| s.ident == "u8")
+                                .unwrap_or(false)
+                        } else {
+                            false
+                        };
+
+                        if is_u8 {
+                            let enc_ident = format_ident!("__enc_{}", i);
+                            quote! {
+                                let #enc_ident = alloy_core::primitives::U256::from(#var_ident as u64);
+                                res.extend_from_slice(&#enc_ident.abi_encode());
+                            }
+                        } else {
+                            quote! {
+                                res.extend_from_slice(&#var_ident.abi_encode());
+                            }
+                        }
+                    })
+                    .collect();
+                quote! { #(#enc_stmts)* }
             }
             Fields::Named(_) => panic!("Named fields are not supported"),
         };
@@ -109,13 +138,65 @@ pub fn error_derive(input: TokenStream) -> TokenStream {
         match &variant.fields {
             Fields::Unit => quote! { selector if selector == #selector_bytes => #name::#variant_name },
             Fields::Unnamed(fields) => {
-                let field_types: Vec<_> = fields.unnamed.iter().map(|f| &f.ty).collect();
-                let indices: Vec<_> = (0..fields.unnamed.len()).collect();
+                // Decode as tuple, upcasting u8 fields to U256, then cast back to u8
+                let dec_types: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .map(|f| {
+                        if let syn::Type::Path(tp) = &f.ty {
+                            let is_u8 = tp
+                                .path
+                                .segments
+                                .last()
+                                .map(|s| s.ident == "u8")
+                                .unwrap_or(false);
+                            if is_u8 {
+                                quote! { alloy_core::primitives::U256 }
+                            } else {
+                                let ty = &f.ty;
+                                quote! { #ty }
+                            }
+                        } else {
+                            let ty = &f.ty;
+                            quote! { #ty }
+                        }
+                    })
+                    .collect();
+                let dec_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|i| format_ident!("__err_dec_{}", i))
+                    .collect();
+                let val_names: Vec<_> = (0..fields.unnamed.len())
+                    .map(|i| format_ident!("__err_val_{}", i))
+                    .collect();
+                let cast_binds: Vec<_> = fields
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(i, f)| {
+                        let dec_n = &dec_names[i];
+                        let val_n = &val_names[i];
+                        let is_u8 = if let syn::Type::Path(tp) = &f.ty {
+                            tp.path
+                                .segments
+                                .last()
+                                .map(|s| s.ident == "u8")
+                                .unwrap_or(false)
+                        } else {
+                            false
+                        };
+                        if is_u8 {
+                            quote! { let #val_n: u8 = #dec_n.as_limbs()[0] as u8; }
+                        } else {
+                            quote! { let #val_n = #dec_n; }
+                        }
+                    })
+                    .collect();
+
                 quote!{ selector if selector == #selector_bytes => {
-                    let mut values = Vec::new();
-                    #( values.push(<#field_types>::abi_decode(data.unwrap()).expect("Unable to decode")); )*
-                    #name::#variant_name(#(values[#indices]),*)
-                }} 
+                    let (#( #dec_names ),*) = <(#( #dec_types ),*)>::abi_decode(data.unwrap()).expect("Unable to decode");
+                    #(#cast_binds)*
+                    #name::#variant_name(#( #val_names ),*)
+                }}
             },
             Fields::Named(_) => panic!("Named fields are not supported"),
         }

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -247,7 +247,7 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
     let field_upcast_exprs: Vec<proc_macro2::TokenStream> = field_types
         .iter()
         .zip(field_names.iter())
-        .map(|(ty, name)| helpers::gen_upcast_expr(quote! { self.#name }, ty))
+        .map(|(ty, name)| helpers::gen_upcast_expr(quote! { (self.#name).clone() }, ty))
         .collect();
 
     let expanded = quote! {

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate proc_macro;
 use alloy_core::primitives::U256;
-use alloy_sol_types::SolValue;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
@@ -69,26 +68,10 @@ pub fn error_derive(input: TokenStream) -> TokenStream {
                     .enumerate()
                     .map(|(i, f)| {
                         let var_ident = format_ident!("_{}", i);
-                        let is_u8 = if let syn::Type::Path(tp) = &f.ty {
-                            tp.path
-                                .segments
-                                .last()
-                                .map(|s| s.ident == "u8")
-                                .unwrap_or(false)
-                        } else {
-                            false
-                        };
-
-                        if is_u8 {
-                            let enc_ident = format_ident!("__enc_{}", i);
-                            quote! {
-                                let #enc_ident = alloy_core::primitives::U256::from(#var_ident as u64);
-                                res.extend_from_slice(&#enc_ident.abi_encode());
-                            }
-                        } else {
-                            quote! {
-                                res.extend_from_slice(&#var_ident.abi_encode());
-                            }
+                        let enc_expr = helpers::gen_upcast_expr(quote! { #var_ident }, &f.ty);
+                        quote! {
+                            let __enc_val = #enc_expr;
+                            res.extend_from_slice(&__enc_val.abi_encode());
                         }
                     })
                     .collect();
@@ -138,29 +121,11 @@ pub fn error_derive(input: TokenStream) -> TokenStream {
         match &variant.fields {
             Fields::Unit => quote! { selector if selector == #selector_bytes => #name::#variant_name },
             Fields::Unnamed(fields) => {
-                // Decode as tuple, upcasting u8 fields to U256, then cast back to u8
+                // Decode as tuple, upcasting nested u8 fields to U256, then cast back recursively
                 let dec_types: Vec<_> = fields
                     .unnamed
                     .iter()
-                    .map(|f| {
-                        if let syn::Type::Path(tp) = &f.ty {
-                            let is_u8 = tp
-                                .path
-                                .segments
-                                .last()
-                                .map(|s| s.ident == "u8")
-                                .unwrap_or(false);
-                            if is_u8 {
-                                quote! { alloy_core::primitives::U256 }
-                            } else {
-                                let ty = &f.ty;
-                                quote! { #ty }
-                            }
-                        } else {
-                            let ty = &f.ty;
-                            quote! { #ty }
-                        }
-                    })
+                    .map(|f| helpers::upcast_type_tokens(&f.ty))
                     .collect();
                 let dec_names: Vec<_> = (0..fields.unnamed.len())
                     .map(|i| format_ident!("__err_dec_{}", i))
@@ -175,20 +140,8 @@ pub fn error_derive(input: TokenStream) -> TokenStream {
                     .map(|(i, f)| {
                         let dec_n = &dec_names[i];
                         let val_n = &val_names[i];
-                        let is_u8 = if let syn::Type::Path(tp) = &f.ty {
-                            tp.path
-                                .segments
-                                .last()
-                                .map(|s| s.ident == "u8")
-                                .unwrap_or(false)
-                        } else {
-                            false
-                        };
-                        if is_u8 {
-                            quote! { let #val_n: u8 = #dec_n.as_limbs()[0] as u8; }
-                        } else {
-                            quote! { let #val_n = #dec_n; }
-                        }
+                        let down_expr = helpers::gen_downcast_expr(quote! { #dec_n }, &f.ty);
+                        quote! { let #val_n = #down_expr; }
                     })
                     .collect();
 
@@ -285,11 +238,26 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
         .map(|f| &f.ident)
         .collect();
 
+    // Precompute Solidity type strings for fields
+    let field_sol_types: Vec<String> = field_types
+        .iter()
+        .map(|ty| helpers::rust_type_to_sol_type(ty).expect("Unknown type").sol_type_name().into_owned())
+        .collect();
+    // Build upcast expressions per field for encoding
+    let field_upcast_exprs: Vec<proc_macro2::TokenStream> = field_types
+        .iter()
+        .zip(field_names.iter())
+        .map(|(ty, name)| helpers::gen_upcast_expr(quote! { self.#name }, ty))
+        .collect();
+
     let expanded = quote! {
         impl #name {
             const NAME: &'static str = stringify!(#name);
             const INDEXED_FIELDS: &'static [&'static str] = &[
                 #(stringify!(#indexed_fields)),*
+            ];
+            const FIELD_TYPES: &'static [&'static str] = &[
+                #(#field_sol_types),*
             ];
 
             pub fn new(#(#field_names: #field_types),*) -> Self {
@@ -301,7 +269,6 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
 
         impl eth_riscv_runtime::log::Event for #name {
             fn encode_log(&self) -> (alloc::vec::Vec<u8>, alloc::vec::Vec<[u8; 32]>) {
-                use alloy_sol_types::SolValue;
                 use alloy_core::primitives::{keccak256, B256};
                 use alloc::vec::Vec;
 
@@ -317,8 +284,13 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
                     if !first { signature.extend_from_slice(b","); }
                     first = false;
 
-                    signature.extend_from_slice(self.#field_names.sol_type_name().as_bytes());
-                    let encoded = self.#field_names.abi_encode();
+                    signature.extend_from_slice(#field_sol_types.as_bytes());
+
+                    let encoded = {
+                        use alloy_sol_types::SolValue;
+                        let __enc_val = #field_upcast_exprs;
+                        __enc_val.abi_encode()
+                    };
 
                     let field_name = stringify!(#field_names);
                     if Self::INDEXED_FIELDS.contains(&field_name) && topics.len() < 4 {
@@ -381,21 +353,15 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 .expect("Unable to generate fn selector")
         );
         let (arg_names, arg_types) = helpers::get_arg_props_skip_first(&method_info);
-        // For ABI decode: replace u8 params with U256, then cast back to u8 before call
-        let is_u8_flags: Vec<bool> = arg_types.iter().map(|ty| {
-            if let syn::Type::Path(tp) = ty {
-                tp.path.segments.last().map(|s| s.ident == "u8").unwrap_or(false)
-            } else { false }
-        }).collect();
-        let dec_types: Vec<proc_macro2::TokenStream> = arg_types.iter().zip(is_u8_flags.iter())
-            .map(|(ty, is_u8)| if *is_u8 { quote! { alloy_core::primitives::U256 } } else { quote! { #ty } })
+        // For ABI decode: upcast nested u8 params to U256 recursively, then cast back before call
+        let dec_types: Vec<proc_macro2::TokenStream> = arg_types.iter()
+            .map(|ty| helpers::upcast_type_tokens(ty))
             .collect();
         let dec_names: Vec<proc_macro2::Ident> = (0..arg_names.len()).map(|i| format_ident!("__arg{}_dec", i)).collect();
-        let cast_binds: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(dec_names.iter()).zip(is_u8_flags.iter())
-            .map(|((name, dec), is_u8)| if *is_u8 {
-                quote! { let #name: u8 = #dec.as_limbs()[0] as u8; }
-            } else {
-                quote! { let #name = #dec; }
+        let cast_binds: Vec<proc_macro2::TokenStream> = arg_names.iter().zip(dec_names.iter()).zip(arg_types.iter())
+            .map(|((name, dec), ty)| {
+                let down_expr = helpers::gen_downcast_expr(quote! { #dec }, ty);
+                quote! { let #name = #down_expr; }
             }).collect();
 
         // Check if there are payable methods
@@ -417,11 +383,17 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
            ReturnType::Type(_,_) => {
                 match helpers::extract_wrapper_types(&method.sig.output) {
-                    helpers::WrapperType::Result(_,_) => quote! {
+                    helpers::WrapperType::Result(_,_) => {
+                        let ok_enc_block = {
+                            let ok_syn = helpers::extract_result_ok_type_syn(&method.sig.output).expect("ok type");
+                            let enc_expr = helpers::gen_upcast_expr(quote! { success }, ok_syn);
+                            quote! { (#enc_expr).abi_encode() }
+                        };
+                        quote! {
                         let res = self.#method_name(#( #arg_names ),*);
                         match res {
                             Ok(success) => {
-                                let result_bytes = success.abi_encode();
+                                let result_bytes = { use alloy_sol_types::SolValue; #ok_enc_block };
                                 let result_size = result_bytes.len() as u64;
                                 let result_ptr = result_bytes.as_ptr() as u64;
                                 eth_riscv_runtime::return_riscv(result_ptr, result_size);
@@ -430,24 +402,43 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
                                 eth_riscv_runtime::revert_with_error(&err.abi_encode());
                             }
                         }
+                    }
                     },
-                    helpers::WrapperType::Option(_) => quote! {
+                    helpers::WrapperType::Option(_) => {
+                        let opt_enc_block = {
+                            let inner_syn = helpers::extract_option_inner_type_syn(&method.sig.output).expect("inner");
+                            let enc_expr = helpers::gen_upcast_expr(quote! { success }, inner_syn);
+                            quote! { (#enc_expr).abi_encode() }
+                        };
+                        quote! {
                         match self.#method_name(#( #arg_names ),*) {
                             Some(success) => {
-                                let result_bytes = success.abi_encode();
+                                let result_bytes = { use alloy_sol_types::SolValue; #opt_enc_block };
                                 let result_size = result_bytes.len() as u64;
                                 let result_ptr = result_bytes.as_ptr() as u64;
                                 eth_riscv_runtime::return_riscv(result_ptr, result_size);
                             },
                             None => eth_riscv_runtime::revert(),
                         }
+                    }
                     },
-                    helpers::WrapperType::None => quote! {
+                    helpers::WrapperType::None => {
+                        let none_enc_block = {
+                            match &method.sig.output {
+                                syn::ReturnType::Type(_, ty) => {
+                                    let enc_expr = helpers::gen_upcast_expr(quote! { result }, ty);
+                                    quote! { (#enc_expr).abi_encode() }
+                                }
+                                syn::ReturnType::Default => quote! { ().abi_encode() },
+                            }
+                        };
+                        quote! {
                         let result = self.#method_name(#( #arg_names ),*);
-                        let result_bytes = result.abi_encode();
+                        let result_bytes = { use alloy_sol_types::SolValue; #none_enc_block };
                         let result_size = result_bytes.len() as u64;
                         let result_ptr = result_bytes.as_ptr() as u64;
                         eth_riscv_runtime::return_riscv(result_ptr, result_size);
+                    }
                     }
                 }
             }
@@ -465,50 +456,18 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let emit_helper = quote! {
         #[macro_export]
-        macro_rules! get_type_signature {
-            ($arg:expr) => {
-                $arg.sol_type_name().as_bytes()
-            };
-        }
-
-        #[macro_export]
         macro_rules! emit {
             ($event:ident, $($field:expr),*) => {{
-                use alloy_sol_types::SolValue;
-                use alloy_core::primitives::{keccak256, B256, U256, I256};
-                use alloc::vec::Vec;
-
-                let mut signature = alloc::vec![];
-                signature.extend_from_slice($event::NAME.as_bytes());
-                signature.extend_from_slice(b"(");
-
-                let mut first = true;
-                let mut topics = alloc::vec![B256::default()];
-                let mut data = Vec::new();
-
-                $(
-                    if !first { signature.extend_from_slice(b","); }
-                    first = false;
-
-                    signature.extend_from_slice(get_type_signature!($field));
-                    let encoded = $field.abi_encode();
-
-                    let field_ident = stringify!($field);
-                    if $event::INDEXED_FIELDS.contains(&field_ident) && topics.len() < 4 {
-                        topics.push(B256::from_slice(&encoded));
-                    } else {
-                        data.extend_from_slice(&encoded);
-                    }
-                )*
-
-                signature.extend_from_slice(b")");
-                topics[0] = B256::from(keccak256(&signature));
-
+                let _e = $event::new($($field),*);
+                let (data, topics) = _e.encode_log();
                 if !data.is_empty() {
                     eth_riscv_runtime::emit_log(&data, &topics);
                 } else if topics.len() > 1 {
-                    let data = topics.pop().unwrap();
-                    eth_riscv_runtime::emit_log(data.as_ref(), &topics);
+                    let mut t = topics.clone();
+                    let data = t.pop().unwrap();
+                    eth_riscv_runtime::emit_log(data.as_ref(), &t);
+                } else {
+                    eth_riscv_runtime::emit_log(&[], &topics);
                 }
             }};
         }

--- a/eth-riscv-runtime/src/create.rs
+++ b/eth-riscv-runtime/src/create.rs
@@ -1,11 +1,120 @@
 extern crate alloc;
-use alloy_core::primitives::{Address, Bytes, U32};
+use alloy_core::primitives::{Address, Bytes, U32, U256};
 use alloy_sol_types::{SolType, SolValue};
 use ext_alloc::vec::Vec;
 use core::{arch::asm, marker::PhantomData, u64};
 use eth_riscv_syscalls::Syscall;
 
 use crate::{FromBuilder, InitInterface, MethodCtx, ReadWrite};
+
+// Minimal, non-invasive ABI upcast helper to mirror contract-derive's u8→U256 handling
+// for constructor argument encoding. Extend as needed.
+trait AbiUpcast {
+    type Output;
+    fn upcast(self) -> Self::Output;
+}
+
+impl AbiUpcast for u8 {
+    type Output = U256;
+    #[inline]
+    fn upcast(self) -> Self::Output {
+        U256::from(self as u64)
+    }
+}
+
+// Identity for common primitives
+impl AbiUpcast for U256 { type Output = U256; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for Address { type Output = Address; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for Bytes { type Output = Bytes; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for alloc::string::String { type Output = alloc::string::String; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for bool { type Output = bool; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u16 { type Output = u16; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u32 { type Output = u32; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u64 { type Output = u64; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u128 { type Output = u128; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i8 { type Output = i8; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i16 { type Output = i16; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i32 { type Output = i32; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i64 { type Output = i64; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i128 { type Output = i128; #[inline] fn upcast(self) -> Self::Output { self } }
+
+// Containers
+impl<T: AbiUpcast> AbiUpcast for alloc::vec::Vec<T> {
+    type Output = alloc::vec::Vec<<T as AbiUpcast>::Output>;
+    #[inline]
+    fn upcast(self) -> Self::Output {
+        self.into_iter().map(|v| v.upcast()).collect()
+    }
+}
+
+impl<T: AbiUpcast + Clone, const N: usize> AbiUpcast for [T; N] {
+    type Output = [<T as AbiUpcast>::Output; N];
+    #[inline]
+    fn upcast(self) -> Self::Output {
+        core::array::from_fn(|i| self[i].clone().upcast())
+    }
+}
+
+// Tuple upcasts (cover common arities used by constructors)
+impl<A: AbiUpcast> AbiUpcast for (A,) {
+    type Output = (A::Output,);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(),) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast> AbiUpcast for (A, B) {
+    type Output = (A::Output, B::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast> AbiUpcast for (A, B, C) {
+    type Output = (A::Output, B::Output, C::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast> AbiUpcast for (A, B, C, D) {
+    type Output = (A::Output, B::Output, C::Output, D::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast> AbiUpcast for (A, B, C, D, E) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast> AbiUpcast for (A, B, C, D, E, F) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast, H: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G, H) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output, H::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast, H: AbiUpcast, I: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G, H, I) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output, H::Output, I::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast(), self.8.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast, H: AbiUpcast, I: AbiUpcast, J: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G, H, I, J) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output, H::Output, I::Output, J::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast(), self.8.upcast(), self.9.upcast()) }
+}
 
 pub trait Deployable {
     type Interface: InitInterface;
@@ -19,10 +128,10 @@ pub trait Deployable {
     }
 
     // Creates a deployment builder that captures the constructor args
-    fn deploy<Args>(args: Args) -> DeploymentBuilder<Self, Args> 
-    where 
+    fn deploy<Args>(args: Args) -> DeploymentBuilder<Self, Args>
+    where
         Self: Sized,
-        Args: SolValue + core::convert::From<<<Args as SolValue>::SolType as SolType>::RustType>
+        Args: AbiUpcast,
     {
         DeploymentBuilder {
             args,
@@ -31,17 +140,17 @@ pub trait Deployable {
     } 
 }
 
-pub struct DeploymentBuilder<D: Deployable + ?Sized, Args> 
+pub struct DeploymentBuilder<D: Deployable + ?Sized, Args>
 where
-    Args: SolValue + core::convert::From<<<Args as SolValue>::SolType as SolType>::RustType>
+    Args: AbiUpcast,
 {
     args: Args,
     _phantom: PhantomData<D>,
 }
 
-impl<D: Deployable, Args> DeploymentBuilder<D, Args> 
+impl<D: Deployable, Args> DeploymentBuilder<D, Args>
 where
-    Args: SolValue + core::convert::From<<<Args as SolValue>::SolType as SolType>::RustType>
+    Args: AbiUpcast,
 {
 
     /// Return the interface with the appropriate context.
@@ -50,16 +159,19 @@ where
     /// - Encodes constructor args using Solidity params-encoding (`abi.encode(a,b,...)`).
     /// - For single-arg constructors, pass a 1-tuple `(arg,)` so the encoder treats it
     ///   as a parameter list; this is critical for dynamic types (string/bytes) parity.
-    pub fn with_ctx<M, T>(self, ctx: M) -> T 
+    pub fn with_ctx<M, T>(self, ctx: M) -> T
     where
         M: MethodCtx<Allowed = ReadWrite>, // Constrain to mutable contexts only
         D::Interface: InitInterface,
         T: FromBuilder<Context = M::Allowed>,
         D::Interface: crate::IntoInterface<T>,
-        for<'a> <<Args as SolValue>::SolType as SolType>::Token<'a>: alloy_sol_types::abi::TokenSeq<'a>
+        for<'a> << <Args as AbiUpcast>::Output as SolValue>::SolType as SolType>::Token<'a>: alloy_sol_types::abi::TokenSeq<'a>,
+        <Args as AbiUpcast>::Output: SolValue,
     {
         let deploy_bin = D::__runtime();
-        let encoded_args = self.args.abi_encode_params();
+        // Upcast nested u8s to U256 before ABI params encoding
+        let upcast_args = self.args.upcast();
+        let encoded_args = upcast_args.abi_encode_params();
 
         // Craft R55 initcode expected by r55-evm:
         // [4-byte codesize][deploy_bin (starts with 0xFF)][constructor_args]

--- a/eth-riscv-runtime/src/create.rs
+++ b/eth-riscv-runtime/src/create.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
-use alloy_core::primitives::{Address, Bytes, U32, U256};
+use alloc::string::String;
+use alloy_core::primitives::{Address, Bytes, U32, U256, I256, FixedBytes};
 use alloy_sol_types::{SolType, SolValue};
 use ext_alloc::vec::Vec;
 use core::{arch::asm, marker::PhantomData, u64};
@@ -8,35 +9,38 @@ use eth_riscv_syscalls::Syscall;
 use crate::{FromBuilder, InitInterface, MethodCtx, ReadWrite};
 
 // Minimal, non-invasive ABI upcast helper to mirror contract-derive's u8→U256 handling
-// for constructor argument encoding. Extend as needed.
+// for constructor argument encoding.
+//
+// Encoding semantics:
+// - bytes (dynamic): use `Bytes` (or `&Bytes`).
+// - uint8[] (dynamic): `Vec<u8>` / `&[u8]` → `Vec<U256>` (element-wise upcast).
+// - fixed arrays: `[T; N]` → `[T::Output; N]` via element upcast (e.g., `[u8; N]` → `[U256; N]`).
+// - bytesN (fixed): pass `FixedBytes<N>` to encode as a single 32-byte word.
+// - tuples: supported up to arity 10.
+// - borrowed forms: `&T`, `&str`, `&[T]` supported without forcing ownership.
+// - single-arg constructors: pass as a 1‑tuple `(arg,)` to use params encoding.
 trait AbiUpcast {
     type Output;
     fn upcast(self) -> Self::Output;
+}
+
+macro_rules! impl_identity_upcast {
+    ($($t:ty),+ $(,)?) => {$(
+        impl AbiUpcast for $t { type Output = $t; #[inline] fn upcast(self) -> Self::Output { self } }
+    )+}
 }
 
 impl AbiUpcast for u8 {
     type Output = U256;
     #[inline]
     fn upcast(self) -> Self::Output {
-        U256::from(self as u64)
+        U256::from(self)
     }
 }
 
-// Identity for common primitives
-impl AbiUpcast for U256 { type Output = U256; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for Address { type Output = Address; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for Bytes { type Output = Bytes; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for alloc::string::String { type Output = alloc::string::String; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for bool { type Output = bool; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u16 { type Output = u16; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u32 { type Output = u32; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u64 { type Output = u64; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u128 { type Output = u128; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i8 { type Output = i8; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i16 { type Output = i16; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i32 { type Output = i32; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i64 { type Output = i64; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i128 { type Output = i128; #[inline] fn upcast(self) -> Self::Output { self } }
+// Identity upcasts
+impl_identity_upcast!(U256, I256, Address, Bytes, String, bool, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+impl<const N: usize> AbiUpcast for FixedBytes<N> { type Output = FixedBytes<N>; #[inline] fn upcast(self) -> Self::Output { self } }
 
 // Containers
 impl<T: AbiUpcast> AbiUpcast for alloc::vec::Vec<T> {
@@ -47,15 +51,45 @@ impl<T: AbiUpcast> AbiUpcast for alloc::vec::Vec<T> {
     }
 }
 
+// Borrowed forms to avoid forcing ownership at call sites
+impl<'a, T> AbiUpcast for &'a T
+where
+    T: AbiUpcast + Clone,
+{
+    type Output = <T as AbiUpcast>::Output;
+    #[inline]
+    fn upcast(self) -> Self::Output { self.clone().upcast() }
+}
+
+impl<'a> AbiUpcast for &'a str {
+    type Output = String;
+    #[inline]
+    fn upcast(self) -> Self::Output { String::from(self) }
+}
+
+impl<'a, T> AbiUpcast for &'a [T]
+where
+    T: AbiUpcast + Clone,
+{
+    type Output = Vec<<T as AbiUpcast>::Output>;
+    #[inline]
+    fn upcast(self) -> Self::Output { self.iter().cloned().map(|v| v.upcast()).collect() }
+}
+
+// Fixed-size arrays: element-wise upcast
 impl<T: AbiUpcast + Clone, const N: usize> AbiUpcast for [T; N] {
     type Output = [<T as AbiUpcast>::Output; N];
     #[inline]
     fn upcast(self) -> Self::Output {
-        core::array::from_fn(|i| self[i].clone().upcast())
+        let arr = self;
+        core::array::from_fn(|i| arr[i].clone().upcast())
     }
 }
 
-// Tuple upcasts (cover common arities used by constructors)
+// Unit tuple for zero-arg constructors
+impl AbiUpcast for () { type Output = (); #[inline] fn upcast(self) -> Self::Output { self } }
+
+// Tuple upcasts (cover common arities used by constructors; limited to 10)
 impl<A: AbiUpcast> AbiUpcast for (A,) {
     type Output = (A::Output,);
     #[inline]
@@ -116,6 +150,7 @@ impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: Ab
     fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast(), self.8.upcast(), self.9.upcast()) }
 }
 
+
 pub trait Deployable {
     type Interface: InitInterface;
 
@@ -169,7 +204,7 @@ where
         <Args as AbiUpcast>::Output: SolValue,
     {
         let deploy_bin = D::__runtime();
-        // Upcast nested u8s to U256 before ABI params encoding
+        // Upcast nested u8 to U256 and preserve shapes (Vec/tuples/[u8;N]) before ABI params encoding
         let upcast_args = self.args.upcast();
         let encoded_args = upcast_args.abi_encode_params();
 


### PR DESCRIPTION
I updated the macro to avoid requiring SolValue for u8 in params by converting on encode and decode.

In the interface client encoding, I now convert any u8 arguments to U256 before calling abi_encode/abi_encode_params.

In the contract dispatch, I decode u8 parameters as U256, then cast back to u8 before invoking the method.