### PR TITLE
fix: r55 events; no casting required

### DIFF
--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -238,26 +238,13 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
         .map(|f| &f.ident)
         .collect();
 
-    // Precompute Solidity type strings for fields
-    let field_sol_types: Vec<String> = field_types
-        .iter()
-        .map(|ty| helpers::rust_type_to_sol_type(ty).expect("Unknown type").sol_type_name().into_owned())
-        .collect();
-    // Build upcast expressions per field for encoding
-    let field_upcast_exprs: Vec<proc_macro2::TokenStream> = field_types
-        .iter()
-        .zip(field_names.iter())
-        .map(|(ty, name)| helpers::gen_upcast_expr(quote! { self.#name }, ty))
-        .collect();
+    // No upcasting needed for events; borrow fields to avoid moves during encoding
 
     let expanded = quote! {
         impl #name {
             const NAME: &'static str = stringify!(#name);
             const INDEXED_FIELDS: &'static [&'static str] = &[
                 #(stringify!(#indexed_fields)),*
-            ];
-            const FIELD_TYPES: &'static [&'static str] = &[
-                #(#field_sol_types),*
             ];
 
             pub fn new(#(#field_names: #field_types),*) -> Self {
@@ -284,12 +271,13 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
                     if !first { signature.extend_from_slice(b","); }
                     first = false;
 
-                    signature.extend_from_slice(#field_sol_types.as_bytes());
+                    // Use runtime SolValue type for signature; supports sol! structs/tuples without precompute
+                    signature.extend_from_slice(self.#field_names.sol_type_name().as_bytes());
 
                     let encoded = {
                         use alloy_sol_types::SolValue;
-                        let __enc_val = #field_upcast_exprs;
-                        __enc_val.abi_encode()
+                        // Borrow when encoding to avoid moving non-Copy fields
+                        (&self.#field_names).abi_encode()
                     };
 
                     let field_name = stringify!(#field_names);

--- a/examples/bridged-erc20/.cargo/config.toml
+++ b/examples/bridged-erc20/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.riscv64imac-unknown-none-elf]
+rustflags = [
+  "-C", "link-arg=-T../../r5-rust-rt.x",
+  "-C", "llvm-args=--inline-threshold=275"
+]
+
+[build]
+target = "riscv64imac-unknown-none-elf"

--- a/examples/bridged-erc20/Cargo.toml
+++ b/examples/bridged-erc20/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "bridged-erc20"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[features]
+default = []
+deploy = []
+interface-only = []
+
+[dependencies]
+contract-derive = { path = "../../contract-derive" }
+eth-riscv-runtime = { path = "../../eth-riscv-runtime" }
+
+alloy-core = { version = "1.3.1", default-features = false }
+alloy-sol-types = { version = "1.3.1", default-features = false }
+
+[[bin]]
+name = "runtime"
+path = "src/lib.rs"
+
+[[bin]]
+name = "deploy"
+path = "src/lib.rs"
+required-features = ["deploy"]
+
+[profile.release]
+lto = true
+opt-level = "z"

--- a/examples/bridged-erc20/src/deployable.rs
+++ b/examples/bridged-erc20/src/deployable.rs
@@ -1,0 +1,10 @@
+//! Auto-generated based on Cargo.toml dependencies
+//! This file provides Deployable implementations for contract dependencies
+//! TODO (phase-2): rather than using `fn deploy(args: Args)`, figure out the constructor selector from the contract dependency
+
+use alloy_core::primitives::{Address, Bytes};
+use eth_riscv_runtime::{create::Deployable, InitInterface, ReadOnly};
+use core::include_bytes;
+
+
+

--- a/examples/bridged-erc20/src/lib.rs
+++ b/examples/bridged-erc20/src/lib.rs
@@ -1,22 +1,15 @@
-//! ERC20 Token Implementation (R55/RISC-V)
+//! Bridged ERC20 Token Implementation (R55/RISC-V)
 //!
-//! A complete ERC20 token implementation compiled to RISC-V bytecode for execution
-//! in the Hydra EVM. This contract provides standard token functionality with ownership
-//! controls and metadata (name, symbol, decimals).
+//! A bridged ERC20 token compiled to RISC-V bytecode for execution in the Hydra EVM.
+//! This contract mirrors BridgedERC20 semantics: bridge-controlled mint/burn, metadata,
+//! and decimals sourced from the origin token.
 //!
 //! ## Features
 //! - Standard ERC20 operations: `transfer`, `approve`, `transferFrom`
-//! - Ownership-based minting with `mint` function
-//! - Token metadata: `name`, `symbol`, `decimals`
-//! - Ownership transfer capability
+//! - Bridge-controlled mint/burn
+//! - Token metadata: `name`, `symbol`, `decimals` (from source token)
 //! - Custom error types for clear revert reasons
 //! - Event emission for all state changes
-//!
-//! ## ABI parity (constructors and calldata)
-//! - Interface calldata mirrors Solidity ABI: single-arg uses `abi_encode()`, multi-arg uses
-//!   `abi_encode_params()`.
-//! - Constructors are params-encoded (equivalent to `abi.encode(a,b,...)`). For single-arg
-//!   constructors, pass a 1-tuple `(arg,)` when using the deploy builder.
 //!
 //! ## Storage
 //! - Uses `DynamicSlot<String>` for name/symbol
@@ -31,9 +24,7 @@ use core::default::Default;
 use contract_derive::{contract, storage, Event, Error};
 use eth_riscv_runtime::types::*;
 
-use alloy_core::primitives::{keccak256 as alloy_keccak256, Address, U256, FixedBytes};
-
-type B32 = FixedBytes<32>;
+use alloy_core::primitives::{Address, U256};
 
 extern crate alloc;
 use alloc::string::String;
@@ -100,22 +91,24 @@ pub enum ERC20Error {
 // CONTRACT STATE
 // =============================================================================
 
-/// ERC20 token contract with ownership controls
+/// Bridged ERC20 token with bridge-controlled mint/burn
 /// 
 /// Storage layout uses Slot-based persistence for fixed-size values.
 /// Dynamic strings for name/symbol are stored via DynamicSlot<String>.
 #[storage]
-pub struct ERC20 {
+pub struct BridgedERC20 {
     /// Total token supply across all holders
     total_supply: Slot<U256>,
     /// Mapping from address to token balance
     balance_of: Mapping<Address, Slot<U256>>,
     /// Nested mapping: owner -> spender -> allowance amount
     allowance_of: Mapping<Address, Mapping<Address, Slot<U256>>>,
-    /// Contract owner (authorized to mint)
-    owner: Slot<Address>,
-    /// Token decimals (typically 18 for standard ERC20)
-    decimals: Slot<U256>,
+    /// Decimals for the source token (returned by decimals())
+    source_token_decimals: Slot<U256>,
+    /// Address of the source token (L1/L2 counterpart)
+    source_token_address: Slot<Address>,
+    /// Bridge contract address (only this address can mint/burn)
+    bridge_address: Slot<Address>,
     /// Token name
     name: DynamicSlot<String>,
     /// Token symbol
@@ -127,27 +120,28 @@ pub struct ERC20 {
 // =============================================================================
 
 #[contract]
-impl ERC20 {
+impl BridgedERC20 {
     // -------------------------------------------------------------------------
     // CONSTRUCTOR
     // -------------------------------------------------------------------------
     
-    /// Initializes a new ERC20 token with metadata
+    /// Initializes a new bridged ERC20 token
     /// 
     /// # Arguments
-    /// * `owner` - Address that will own the contract and have minting rights
-    /// * `name` - Human-readable token name (e.g., "Ethereum")
-    /// * `symbol` - Trading symbol (e.g., "ETH")
-    /// * `decimals` - Number of decimal places (typically 18)
+    /// * `name` - Human-readable token name
+    /// * `symbol` - Trading symbol
+    /// * `decimals` - Decimals for the source token
+    /// * `source_token` - Address of the source token on the origin chain
     /// 
     /// # Returns
     /// Initialized ERC20 contract instance
-    pub fn new(owner: Address, name: String, symbol: String, decimals: U256) -> Self {
-        let mut erc20 = ERC20::default();
+    pub fn new(name: String, symbol: String, decimals: U256, source_token: Address, erc20_bridge: Address) -> Self {
+        let mut erc20 = BridgedERC20::default();
 
-        // Update state
-        erc20.owner.write(owner);
-        erc20.decimals.write(decimals);
+        // Bridge authority and source info
+        erc20.bridge_address.write(erc20_bridge);
+        erc20.source_token_decimals.write(decimals);
+        erc20.source_token_address.write(source_token);
 
         // Store dynamic metadata
         erc20.name.write(name);
@@ -160,7 +154,7 @@ impl ERC20 {
     // STATE-MODIFYING FUNCTIONS
     // -------------------------------------------------------------------------
     
-    /// Mints new tokens to a specified address (owner only)
+    /// Mints new tokens to a specified address (bridge only)
     /// 
     /// Increases recipient balance and total supply.
     /// Emits Transfer event with `from` = Address::ZERO.
@@ -172,11 +166,11 @@ impl ERC20 {
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error)` on validation failure
-    pub fn mint(&mut self, to: Address, amount: U256) -> Result<bool, ERC20Error> {
-        // Access control: only owner can mint
-        if msg_sender() != self.owner.read() { return Err(ERC20Error::OnlyOwner) }; 
-        if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
-        if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
+    pub fn mint(&mut self, to: Address, amount: U256) {
+        // Access control: only bridge can mint
+        if msg_sender() != self.bridge_address.read() { eth_riscv_runtime::revert(); };
+        if amount == U256::ZERO { eth_riscv_runtime::revert(); };
+        if to == Address::ZERO { eth_riscv_runtime::revert(); };
 
         // Update recipient balance
         let to_balance = self.balance_of[to].read();
@@ -187,7 +181,23 @@ impl ERC20 {
         
         // Emit Transfer event (from = 0x0 for mints)
         log::emit(Transfer::new(Address::ZERO, to, amount));
-        Ok(true)
+    }
+
+    /// Burns tokens from the bridge address (bridge only)
+    /// Decreases sender balance and total supply.
+    pub fn burn(&mut self, amount: U256) {
+        // Access control: only bridge can burn
+        let bridge = msg_sender();
+        if bridge != self.bridge_address.read() { eth_riscv_runtime::revert(); };
+        if amount == U256::ZERO { eth_riscv_runtime::revert(); };
+
+        let bal = self.balance_of[bridge].read();
+        if bal < amount { eth_riscv_runtime::revert(); };
+
+        self.balance_of[bridge].write(bal - amount);
+        self.total_supply.write(self.total_supply.read() - amount);
+
+        log::emit(Transfer::new(bridge, Address::ZERO, amount));
     }
 
     /// Sets spending allowance for a spender
@@ -259,27 +269,20 @@ impl ERC20 {
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error)` on insufficient allowance or balance
-    /// * Update to use camelCase for Solidity selector parity (across all functions)
     pub fn transferFrom(&mut self, from: Address, to: Address, amount: U256) -> Result<bool, ERC20Error> {
-        let msg_sender = msg_sender();
+        let caller = msg_sender();
 
-        // Validation checks
         if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
         if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
         if from == to { return Err(ERC20Error::SelfTransfer) };
 
-        // Check allowance (caller must be approved by `from`)
-        let allowance = self.allowance_of[from][msg_sender].read();
+        let allowance = self.allowance_of[from][caller].read();
         if allowance < amount { return Err(ERC20Error::InsufficientAllowance(allowance)) };
 
-        // Check balance
         let from_balance = self.balance_of[from].read();
         if from_balance < amount { return Err(ERC20Error::InsufficientBalance(from_balance)) };
 
-        // Update allowance (decrease by amount spent)
-        self.allowance_of[from][msg_sender].write(allowance - amount);
-        
-        // Update balances atomically
+        self.allowance_of[from][caller].write(allowance - amount);
         self.balance_of[from].write(from_balance - amount);
         let to_balance = self.balance_of[to].read();
         self.balance_of[to].write(to_balance + amount);
@@ -288,56 +291,36 @@ impl ERC20 {
         Ok(true)
     }
 
-    /// Transfers contract ownership to a new address (owner only)
-    /// 
-    /// New owner will have minting rights.
-    /// 
-    /// # Arguments
-    /// * `new_owner` - New contract owner
-    /// 
-    /// # Returns
-    /// * `Ok(true)` on success
-    /// * `Err(ERC20Error::OnlyOwner)` if caller is not owner
-    pub fn transferOwnership(&mut self, new_owner: Address) -> Result<bool, ERC20Error> {
-        let from = msg_sender();
-
-        // Access control + validation
-        if from != self.owner.read() { return Err(ERC20Error::OnlyOwner) }; 
-        if from == new_owner { return Err(ERC20Error::SelfTransfer) }; 
-
-        // Update owner
-        self.owner.write(new_owner);
-
-        log::emit(OwnershipTransferred::new(from, new_owner));
-        Ok(true)
-    }
+    // No ownership transfer in bridged token; bridge is immutable authority.
 
     // -------------------------------------------------------------------------
     // VIEW FUNCTIONS
     // -------------------------------------------------------------------------
     
-    /// Returns the current contract owner address
-    pub fn owner(&self) -> Address {
-        self.owner.read()
-    }
-
-    /// CamelCase view: totalSupply() -> uint256 (Solidity selector parity)
+    /// ERC20 camelCase view: totalSupply()
     pub fn totalSupply(&self) -> U256 { self.total_supply.read() }
 
-    /// CamelCase view: balanceOf(address) -> uint256 (Solidity selector parity)
+    /// ERC20 camelCase view: balanceOf(address)
     pub fn balanceOf(&self, owner: Address) -> U256 {
         self.balance_of[owner].read()
     }
 
-    /// Returns the allowance granted by owner to spender (Solidity selector parity)
+    /// Returns the allowance granted by owner to spender
     pub fn allowance(&self, owner: Address, spender: Address) -> U256 {
         self.allowance_of[owner][spender].read()
     }
 
-    /// Returns token decimals (standard is 18)
-    pub fn decimals(&self) -> U256 {
-        self.decimals.read()
-    }
+    /// Returns token decimals (from source token)
+    pub fn decimals(&self) -> U256 { self.source_token_decimals.read() }
+
+    /// Getter parity with Solidity public immutable: sourceTokenDecimals()
+    pub fn sourceTokenDecimals(&self) -> U256 { self.source_token_decimals.read() }
+
+    /// Getter parity with Solidity public immutable: sourceTokenAddress()
+    pub fn sourceTokenAddress(&self) -> Address { self.source_token_address.read() }
+
+    /// Getter parity with Solidity public immutable: bridgeAddress()
+    pub fn bridgeAddress(&self) -> Address { self.bridge_address.read() }
 
     // -------------------------------------------------------------------------
     // METADATA (IERC20Metadata)

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -28,10 +28,10 @@
 
 use core::default::Default;
 
-use contract_derive::{contract, storage, Event, Error};
+use contract_derive::{contract, storage, Error, Event};
 use eth_riscv_runtime::types::*;
 
-use alloy_core::primitives::{keccak256 as alloy_keccak256, Address, U256, FixedBytes};
+use alloy_core::primitives::{keccak256 as alloy_keccak256, Address, FixedBytes, U256};
 
 type B32 = FixedBytes<32>;
 
@@ -101,7 +101,7 @@ pub enum ERC20Error {
 // =============================================================================
 
 /// ERC20 token contract with ownership controls
-/// 
+///
 /// Storage layout uses Slot-based persistence for fixed-size values.
 /// Dynamic strings for name/symbol are stored via DynamicSlot<String>.
 #[storage]
@@ -131,15 +131,15 @@ impl ERC20 {
     // -------------------------------------------------------------------------
     // CONSTRUCTOR
     // -------------------------------------------------------------------------
-    
+
     /// Initializes a new ERC20 token with metadata
-    /// 
+    ///
     /// # Arguments
     /// * `owner` - Address that will own the contract and have minting rights
     /// * `name` - Human-readable token name (e.g., "Ethereum")
     /// * `symbol` - Trading symbol (e.g., "ETH")
     /// * `decimals` - Number of decimal places (typically 18)
-    /// 
+    ///
     /// # Returns
     /// Initialized ERC20 contract instance
     pub fn new(owner: Address, name: String, symbol: String, decimals: U256) -> Self {
@@ -159,24 +159,30 @@ impl ERC20 {
     // -------------------------------------------------------------------------
     // STATE-MODIFYING FUNCTIONS
     // -------------------------------------------------------------------------
-    
+
     /// Mints new tokens to a specified address (owner only)
-    /// 
+    ///
     /// Increases recipient balance and total supply.
     /// Emits Transfer event with `from` = Address::ZERO.
-    /// 
+    ///
     /// # Arguments
     /// * `to` - Recipient address
     /// * `amount` - Tokens to mint
-    /// 
+    ///
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error)` on validation failure
     pub fn mint(&mut self, to: Address, amount: U256) -> Result<bool, ERC20Error> {
         // Access control: only owner can mint
-        if msg_sender() != self.owner.read() { return Err(ERC20Error::OnlyOwner) }; 
-        if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
-        if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
+        if msg_sender() != self.owner.read() {
+            return Err(ERC20Error::OnlyOwner);
+        };
+        if amount == U256::ZERO {
+            return Err(ERC20Error::ZeroAmount);
+        };
+        if to == Address::ZERO {
+            return Err(ERC20Error::ZeroAddress);
+        };
 
         // Update recipient balance
         let to_balance = self.balance_of[to].read();
@@ -184,20 +190,20 @@ impl ERC20 {
 
         // Update total supply
         self.total_supply += amount;
-        
+
         // Emit Transfer event (from = 0x0 for mints)
         log::emit(Transfer::new(Address::ZERO, to, amount));
         Ok(true)
     }
 
     /// Sets spending allowance for a spender
-    /// 
+    ///
     /// Allows `spender` to withdraw up to `amount` tokens via transferFrom().
-    /// 
+    ///
     /// # Arguments
     /// * `spender` - Address authorized to spend
     /// * `amount` - Maximum spendable amount
-    /// 
+    ///
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error)` on validation failure
@@ -205,8 +211,12 @@ impl ERC20 {
         let owner = msg_sender();
 
         // Validation checks
-        if spender == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
-        if spender == owner { return Err(ERC20Error::SelfApproval) };
+        if spender == Address::ZERO {
+            return Err(ERC20Error::ZeroAddress);
+        };
+        if spender == owner {
+            return Err(ERC20Error::SelfApproval);
+        };
 
         // Update allowance mapping
         self.allowance_of[owner][spender].write(amount);
@@ -216,11 +226,11 @@ impl ERC20 {
     }
 
     /// Transfers tokens from caller to another address
-    /// 
+    ///
     /// # Arguments
     /// * `to` - Recipient address
     /// * `amount` - Tokens to transfer
-    /// 
+    ///
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error)` on validation failure or insufficient balance
@@ -228,16 +238,24 @@ impl ERC20 {
         let from = msg_sender();
 
         // Validation checks
-        if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
-        if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
-        if from == to { return Err(ERC20Error::SelfTransfer) };
+        if to == Address::ZERO {
+            return Err(ERC20Error::ZeroAddress);
+        };
+        if amount == U256::ZERO {
+            return Err(ERC20Error::ZeroAmount);
+        };
+        if from == to {
+            return Err(ERC20Error::SelfTransfer);
+        };
 
         // Load current balances
         let from_balance = self.balance_of[from].read();
         let to_balance = self.balance_of[to].read();
 
         // Check sufficient balance
-        if from_balance < amount { return Err(ERC20Error::InsufficientBalance(from_balance)) }
+        if from_balance < amount {
+            return Err(ERC20Error::InsufficientBalance(from_balance));
+        }
 
         // Update balances atomically
         self.balance_of[from].write(from_balance - amount);
@@ -248,37 +266,52 @@ impl ERC20 {
     }
 
     /// Transfers tokens on behalf of another address using allowance
-    /// 
+    ///
     /// Caller must have sufficient allowance from `from` address.
-    /// 
+    ///
     /// # Arguments
     /// * `from` - Token owner (must have approved caller)
     /// * `to` - Recipient address
     /// * `amount` - Tokens to transfer
-    /// 
+    ///
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error)` on insufficient allowance or balance
     /// * Update to use camelCase for Solidity selector parity (across all functions)
-    pub fn transferFrom(&mut self, from: Address, to: Address, amount: U256) -> Result<bool, ERC20Error> {
+    pub fn transferFrom(
+        &mut self,
+        from: Address,
+        to: Address,
+        amount: U256,
+    ) -> Result<bool, ERC20Error> {
         let msg_sender = msg_sender();
 
         // Validation checks
-        if to == Address::ZERO { return Err(ERC20Error::ZeroAddress) };
-        if amount == U256::ZERO { return Err(ERC20Error::ZeroAmount) };
-        if from == to { return Err(ERC20Error::SelfTransfer) };
+        if to == Address::ZERO {
+            return Err(ERC20Error::ZeroAddress);
+        };
+        if amount == U256::ZERO {
+            return Err(ERC20Error::ZeroAmount);
+        };
+        if from == to {
+            return Err(ERC20Error::SelfTransfer);
+        };
 
         // Check allowance (caller must be approved by `from`)
         let allowance = self.allowance_of[from][msg_sender].read();
-        if allowance < amount { return Err(ERC20Error::InsufficientAllowance(allowance)) };
+        if allowance < amount {
+            return Err(ERC20Error::InsufficientAllowance(allowance));
+        };
 
         // Check balance
         let from_balance = self.balance_of[from].read();
-        if from_balance < amount { return Err(ERC20Error::InsufficientBalance(from_balance)) };
+        if from_balance < amount {
+            return Err(ERC20Error::InsufficientBalance(from_balance));
+        };
 
         // Update allowance (decrease by amount spent)
         self.allowance_of[from][msg_sender].write(allowance - amount);
-        
+
         // Update balances atomically
         self.balance_of[from].write(from_balance - amount);
         let to_balance = self.balance_of[to].read();
@@ -289,12 +322,12 @@ impl ERC20 {
     }
 
     /// Transfers contract ownership to a new address (owner only)
-    /// 
+    ///
     /// New owner will have minting rights.
-    /// 
+    ///
     /// # Arguments
     /// * `new_owner` - New contract owner
-    /// 
+    ///
     /// # Returns
     /// * `Ok(true)` on success
     /// * `Err(ERC20Error::OnlyOwner)` if caller is not owner
@@ -302,8 +335,12 @@ impl ERC20 {
         let from = msg_sender();
 
         // Access control + validation
-        if from != self.owner.read() { return Err(ERC20Error::OnlyOwner) }; 
-        if from == new_owner { return Err(ERC20Error::SelfTransfer) }; 
+        if from != self.owner.read() {
+            return Err(ERC20Error::OnlyOwner);
+        };
+        if from == new_owner {
+            return Err(ERC20Error::SelfTransfer);
+        };
 
         // Update owner
         self.owner.write(new_owner);
@@ -315,14 +352,16 @@ impl ERC20 {
     // -------------------------------------------------------------------------
     // VIEW FUNCTIONS
     // -------------------------------------------------------------------------
-    
+
     /// Returns the current contract owner address
     pub fn owner(&self) -> Address {
         self.owner.read()
     }
 
     /// CamelCase view: totalSupply() -> uint256 (Solidity selector parity)
-    pub fn totalSupply(&self) -> U256 { self.total_supply.read() }
+    pub fn totalSupply(&self) -> U256 {
+        self.total_supply.read()
+    }
 
     /// CamelCase view: balanceOf(address) -> uint256 (Solidity selector parity)
     pub fn balanceOf(&self, owner: Address) -> U256 {
@@ -342,10 +381,14 @@ impl ERC20 {
     // -------------------------------------------------------------------------
     // METADATA (IERC20Metadata)
     // -------------------------------------------------------------------------
-    
+
     /// Returns token name
-    pub fn name(&self) -> String { self.name.read() }
+    pub fn name(&self) -> String {
+        self.name.read()
+    }
 
     /// Returns token symbol
-    pub fn symbol(&self) -> String { self.symbol.read() }
+    pub fn symbol(&self) -> String {
+        self.symbol.read()
+    }
 }

--- a/examples/hydra-erc20-bridge/Cargo.toml
+++ b/examples/hydra-erc20-bridge/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "hydra-erc20-bridge"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[features]
+default = []
+deploy = []
+interface-only = []
+
+[dependencies]
+contract-derive = { path = "../../contract-derive" }
+eth-riscv-runtime = { path = "../../eth-riscv-runtime" }
+bridged-erc20 = { path = "../bridged-erc20", features = ["interface-only"] }
+
+alloy-core = { version = "1.3.1", default-features = false }
+alloy-sol-types = { version = "1.3.1", default-features = false }
+
+[[bin]]
+name = "runtime"
+path = "src/lib.rs"
+
+[[bin]]
+name = "deploy"
+path = "src/lib.rs"
+required-features = ["deploy"]
+
+[profile.release]
+lto = true
+opt-level = "z"

--- a/examples/hydra-erc20-bridge/src/deployable.rs
+++ b/examples/hydra-erc20-bridge/src/deployable.rs
@@ -1,0 +1,22 @@
+//! Auto-generated based on Cargo.toml dependencies
+//! This file provides Deployable implementations for contract dependencies
+//! TODO (phase-2): rather than using `fn deploy(args: Args)`, figure out the constructor selector from the contract dependency
+
+use alloy_core::primitives::{Address, Bytes};
+use eth_riscv_runtime::{create::Deployable, InitInterface, ReadOnly};
+use core::include_bytes;
+
+use bridged_erc20::IBridgedERC20;
+
+const BRIDGEDERC20_BYTECODE: &'static [u8] = include_bytes!("../../../r55-output-bytecode/bridged-erc20.bin");
+
+pub struct BridgedERC20;
+
+impl Deployable for BridgedERC20 {
+    type Interface = IBridgedERC20<ReadOnly>;
+
+    fn __runtime() -> &'static [u8] {
+        BRIDGEDERC20_BYTECODE
+    }
+}
+

--- a/examples/hydra-erc20-bridge/src/lib.rs
+++ b/examples/hydra-erc20-bridge/src/lib.rs
@@ -1,0 +1,538 @@
+//! ERC20Bridge (R55/RISC-V)
+//!
+//! Cross-chain ERC20 bridge, mirroring the Solidity reference interface.
+//!
+//! Solidity refs:
+//! /Users/michael/Documents/stack/stack/contracts/src/shared/interfaces/IERC20Bridge.sol
+//! /Users/michael/Documents/stack/stack/contracts/src/shared/SignalService.sol
+//!
+//! R55 refs:
+//! /Users/michael/Documents/stack/r55/examples/hydra-erc20-bridge/src/lib.rs
+
+#![no_std]
+#![no_main]
+
+use alloy_core::primitives::{keccak256 as alloy_keccak256, Address, Bytes, FixedBytes, U256};
+use alloy_sol_types::sol;
+use contract_derive::{contract, storage, Event};
+use eth_riscv_runtime::types::*;
+use eth_riscv_runtime::{revert};
+
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+type B32 = FixedBytes<32>;
+
+mod deployable;
+use deployable::BridgedERC20;
+
+// Using proper Deployable interface for BridgedERC20; runtime bytecode is wired in deployable.rs
+
+sol! {
+    struct TokenDescription {
+        // The source token address on the source chain
+        address sourceToken;
+        // The token name
+        string name;
+        // The token symbol
+        string symbol;
+        // The token decimals
+        uint8 decimals;
+    }
+
+    struct ERC20Deposit {
+        // The nonce of the deposit
+        uint256 nonce;
+        // The sender of the deposit
+        address from;
+        // The receiver of the deposit
+        address to;
+        // The source ERC20 token address (always refers to the source token, not bridged)
+        address sourceToken;
+        // The amount of the deposit
+        uint256 amount;
+    }
+}
+
+// Events (parity with Solidity)
+#[derive(Event)]
+struct TokenDescriptionRecorded {
+    #[indexed]
+    id: B32,
+    description: TokenDescription,
+}
+
+#[derive(Event)]
+struct CounterpartTokenDeployed {
+    #[indexed]
+    id: B32,
+    description: TokenDescription,
+    #[indexed]
+    deployed_token: Address,
+}
+
+#[derive(Event)]
+struct DepositMade {
+    #[indexed]
+    id: B32,
+    deposit: ERC20Deposit,
+    local_token: Address,
+}
+
+#[derive(Event)]
+struct DepositClaimed {
+    #[indexed]
+    id: B32,
+    deposit: ERC20Deposit,
+}
+
+// *** Interfaces currently commented out because r55 cannot support multiple interface macros
+// *** This is because #[interface("camelCase")] re-imports multiple of the same traits/crates, and rust complains
+// *** Applied a simple fix in /Users/michael/Documents/stack/r55/contract-derive/src/helpers.rs
+// *** But r55-compile uses the develop branch so my local changes are not applied
+// *** TODO: Fix in r55, or compile in r55 and copy the bytecode binary here
+
+// /// SignalService interface (ABI encoding via r55 interface macro)
+// #[interface("camelCase")]
+// trait ISignalService {
+//     fn verifySignal(&mut self, sender: Address, value: B32, proof: Bytes);
+//     fn sendSignal(&mut self, value: B32) -> B32;
+// }
+
+// /// Minimal ERC20 interface used by the bridge
+// #[interface("camelCase")]
+// trait IERC20 {
+//     fn transfer(&mut self, to: Address, amount: U256) -> bool;
+//     fn transferFrom(&mut self, from: Address, to: Address, amount: U256) -> bool;
+// }
+
+// /// Bridged ERC20 interface (destination chain representation)
+// #[interface("camelCase")]
+// trait IBridgedERC20 {
+//     fn mint(&mut self, to: Address, amount: U256);
+//     fn burn(&mut self, amount: U256);
+//     fn sourceTokenAddress(&self) -> Address;
+// }
+
+// /// ERC20 metadata interface used to read token name/symbol/decimals
+// #[interface("camelCase")]
+// trait IERC20Metadata {
+//     fn name(&self) -> String;
+//     fn symbol(&self) -> String;
+//     fn decimals(&self) -> U256;
+// }
+
+#[storage]
+pub struct ERC20Bridge {
+    // Processed ids (1 = processed)
+    processed: Mapping<B32, Slot<U256>>,
+    // Source token -> deployed counterpart (on local chain)
+    counterpart_token_of: Mapping<Address, Slot<Address>>,
+    // Token address -> is bridged (1) or not (0)
+    is_bridged_token: Mapping<Address, Slot<U256>>,
+    // Global nonce for ERC20 deposits
+    global_deposit_nonce: Slot<U256>,
+    // Addresses
+    signal_service: Slot<Address>,
+    counterpart: Slot<Address>,
+    this_address: Slot<Address>,
+    // Reentrancy guard
+    reentrancy_entered: Slot<U256>,
+}
+
+#[contract]
+impl ERC20Bridge {
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+    pub fn new(signal_service: Address, counterpart: Address, _this_address: Address) -> Self {
+        if signal_service == Address::ZERO || counterpart == Address::ZERO { revert(); }
+        let mut s = ERC20Bridge::default();
+        s.signal_service.write(signal_service);
+        s.counterpart.write(counterpart);
+        s.this_address.write(_this_address);
+        s
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// processed(bytes32 id) -> bool
+    pub fn processed(&self, id: B32) -> bool {
+        self.processed[id].read() == U256::from(1u8)
+    }
+
+    /// signalService() -> address
+    pub fn signalService(&self) -> Address {
+        self.signal_service.read()
+    }
+
+    /// counterpart() -> address
+    pub fn counterpart(&self) -> Address {
+        self.counterpart.read()
+    }
+
+    /// getCounterpartToken(address sourceToken) -> address
+    pub fn getCounterpartToken(&self, source_token: Address) -> Address {
+        self.counterpart_token_of[source_token].read()
+    }
+
+    /// getTokenDescriptionId(TokenDescription) -> bytes32
+    /// Computes keccak256(abi.encode(TOKEN_DESCRIPTION_SIGNAL_PREFIX, TokenDescription)).
+    ///
+    /// IMPORTANT (ABI parity note):
+    /// - Solidity encodes two parameters here: `(prefix, tokenDesc)`.
+    /// - `alloy_sol_types::SolValue::abi_encode` encodes ONE value. Passing `(prefix, tokenDesc)`
+    ///   to `abi_encode` encodes a single tuple value, which diverges in layout for dynamic members
+    ///   (e.g. `string name`, `string symbol`).
+    /// - Use `abi_encode_params(&(prefix, tokenDesc))` to encode “two params” exactly like
+    ///   Solidity `abi.encode(prefix, tokenDesc)`.
+    ///
+    /// NOTE (alloy uint8 limitation):
+    /// - alloy 1.3.x does not implement `SolValue` for Rust primitive `u8`.
+    ///   Encoding must use types with `SolValue` impls (e.g. `I256`/`U256`) or a signed `i8`
+    ///   casted to `I256` for parity with Solidity’s int widening rules.
+    /// - If/when alloy adds `SolValue` for `u8`/`uint8`, this function can accept `u8` directly
+    ///   and drop the explicit `I256` cast. References:
+    ///   - SolValue trait: https://docs.rs/alloy-sol-types/1.3.1/alloy_sol_types/trait.SolValue.html
+    ///   - I256: https://docs.rs/alloy-core/1.3.1/alloy_core/primitives/struct.I256.html
+    ///   - U256: https://docs.rs/alloy-core/1.3.1/alloy_core/primitives/struct.U256.html
+    pub fn getTokenDescriptionId(
+        &self,
+        token_desc: (Address, String, String, u8),
+    ) -> B32 {
+        let prefix = token_description_prefix();
+        let (source, name, symbol, decimals) = token_desc;
+        // Match Solidity: keccak256(abi.encode(prefix, TokenDescription)) where TokenDescription is a tuple param
+        let td = TokenDescription { sourceToken: source, name, symbol, decimals };
+        let params = (prefix, td);
+        let bytes = alloy_sol_types::SolValue::abi_encode_params(&params);
+        B32::from(alloy_keccak256(&bytes))
+    }
+
+    /// getDepositId(ERC20Deposit) -> bytes32
+    /// Computes keccak256(abi.encode(ERC20Deposit)).
+    ///
+    /// NOTE: This currently works with `abi_encode` because `ERC20Deposit` is all static types.
+    /// For static-only inner tuples, encoding a single tuple vs. multiple params produces identical
+    /// bytes. If any dynamic field is ever added here, switch to `abi_encode_params(&(prefix, erc20Deposit))`
+    /// to preserve Solidity parity.
+    pub fn getDepositId(
+        &self,
+        erc20_deposit: (U256, Address, Address, Address, U256),
+    ) -> B32 {
+        let prefix = deposit_prefix();
+        let tuple = (prefix, erc20_deposit);
+        B32::from(alloy_keccak256(&alloy_sol_types::SolValue::abi_encode(&tuple)))
+    }
+
+    // ---------------------------------------------------------------------
+    // Mutating functions (scaffolded)
+    // ---------------------------------------------------------------------
+
+    /// recordTokenDescription(address token) -> bytes32
+    pub fn recordTokenDescription(&mut self, token: Address) -> B32 {
+        // Parity checks
+        if token == Address::ZERO { revert(); }
+        if self.is_bridged_token[token].read() == U256::from(1u8) { revert(); }
+
+        // --- Read token metadata; if all three fail, mirror base revert behavior ---
+        // Try/catch parity: each metadata call may fail independently; apply per-field fallbacks
+        let name = erc20_metadata_name(token).unwrap_or_else(|| String::from("Unknown Token Name"));
+        let symbol = erc20_metadata_symbol(token).unwrap_or_else(|| String::from("UNKNOWN"));
+        let decimals_u8: u8 = erc20_metadata_decimals(token).unwrap_or(18);
+
+        // Compute ID using params-encode
+        // IMPORTANT: Solidity encodes two params `(prefix, tokenDesc)`; use abi_encode_params
+        let id = {
+            let prefix = token_description_prefix();
+            let td = TokenDescription { sourceToken: token, name: name.clone(), symbol: symbol.clone(), decimals: decimals_u8 };
+            let params = (prefix, td);
+            let bytes = alloy_sol_types::SolValue::abi_encode_params(&params);
+            B32::from(alloy_keccak256(&bytes))
+        };
+
+        // Rebuild TokenDescription to move into event payload
+        let token_desc = TokenDescription { sourceToken: token, name, symbol, decimals: decimals_u8 };
+
+        // Signal via SignalService: sendSignal(bytes32) -> bytes32 (slot)
+        // Propagate revert on failure to match Solidity behavior
+        let sig_addr = self.signal_service.read();
+        let mut calldata = Vec::with_capacity(4 + 32);
+        calldata.extend_from_slice(&function_selector(b"sendSignal(bytes32)"));
+        calldata.extend_from_slice(id.as_slice());
+        match eth_riscv_runtime::call::call_contract(sig_addr, 0, &calldata, Some(32)) {
+            Ok(_) => { /* ignore returned slot */ }
+            Err(_) => { revert(); }
+        }
+
+        // Emit TokenDescriptionRecorded(id, tokenDesc)
+        eth_riscv_runtime::log::emit(TokenDescriptionRecorded { id, description: token_desc });
+
+        id
+    }
+
+    /// deployCounterpartToken(TokenDescription tokenDesc, bytes proof) -> address
+    pub fn deployCounterpartToken(
+        &mut self,
+        token_desc: (Address, String, String, u8),
+        proof: Bytes,
+    ) -> Address {
+        // tokenDesc tuple unpack
+        let (source_token, name, symbol, decimals_u8) = token_desc;
+
+        // Compute id = keccak256(abi.encode(TOKEN_DESCRIPTION_SIGNAL_PREFIX, tokenDesc))
+        let id = self.getTokenDescriptionId((
+            source_token,
+            name.clone(),
+            symbol.clone(),
+            decimals_u8,
+        ));
+
+        // require(!_processed[id])
+        if self.processed[id].read() == U256::from(1u8) { revert(); }
+
+        // require(_counterpartTokens[sourceToken] == address(0))
+        if self.counterpart_token_of[source_token].read() != Address::ZERO { revert(); }
+
+        // signalService.verifySignal(counterpart, id, proof)
+        // ABI: verifySignal(address,bytes32,bytes)
+        let sig_addr = self.signal_service.read();
+        let counterparty = self.counterpart.read();
+        let mut calldata = Vec::new();
+        calldata.extend_from_slice(&function_selector(b"verifySignal(address,bytes32,bytes)"));
+        let args = (counterparty, id, proof.clone());
+        calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&args));
+        match eth_riscv_runtime::call::call_contract(sig_addr, 0, &calldata, None) {
+            Ok(_) => {}
+            Err(_) => { revert(); }
+        }
+
+        // Read this_address
+        let this_address = self.this_address.read();
+
+        // Deploy bridged token using R55 Deployable builder (intentionally using R55 bytecode)
+        let child = BridgedERC20::deploy((
+            name.clone(),
+            symbol.clone(),
+            U256::from(decimals_u8),
+            source_token,
+            this_address,
+        ))
+        .with_ctx(&mut *self);
+        let deployed = child.address();
+
+        if deployed == Address::ZERO { revert(); }
+
+        // _counterpartTokens[source] = deployed; _isBridgedTokens[deployed] = true; _processed[id] = true
+        self.counterpart_token_of[source_token].write(deployed);
+        self.is_bridged_token[deployed].write(U256::from(1u8));
+        self.processed[id].write(U256::from(1u8));
+
+        // Emit CounterpartTokenDeployed(id, tokenDesc, deployed)
+        let td = TokenDescription { sourceToken: source_token, name, symbol, decimals: decimals_u8 };
+        eth_riscv_runtime::log::emit(CounterpartTokenDeployed { id, description: td, deployed_token: deployed });
+
+        deployed
+    }
+
+    /// deposit(address to, address localToken, uint256 amount) -> bytes32
+    pub fn deposit(&mut self, _to: Address, _local_token: Address, _amount: U256) -> B32 {
+        // Resolve bridged vs local token
+        let is_bridged = self.is_bridged_token[_local_token].read() == U256::from(1u8);
+
+        // sourceToken = isBridged ? BridgedERC20(localToken).sourceTokenAddress() : localToken
+        let source_token = if is_bridged {
+            let mut calldata = Vec::with_capacity(4);
+            calldata.extend_from_slice(&function_selector(b"sourceTokenAddress()"));
+            match eth_riscv_runtime::call::staticcall_contract(_local_token, 0, &calldata, None) {
+                Ok(bytes) => {
+                    if let Ok(addr) = <Address as alloy_sol_types::SolValue>::abi_decode(&bytes) {
+                        addr
+                    } else {
+                        revert()
+                    }
+                }
+                Err(_) => { revert() }
+            }
+        } else {
+            _local_token
+        };
+
+        // Build deposit tuple
+        let nonce = self.global_deposit_nonce.read();
+        let from = eth_riscv_runtime::msg_sender();
+        let to = _to;
+        let amount = _amount;
+        let deposit_tuple = (nonce, from, to, source_token, amount);
+
+        // Compute id = keccak256(abi.encode(DEPOSIT_SIGNAL_PREFIX, erc20Deposit))
+        let id = self.getDepositId(deposit_tuple);
+
+        // Increment nonce (unchecked in Solidity semantics)
+        self.global_deposit_nonce.write(nonce.saturating_add(U256::from(1u8)));
+
+        // IERC20(localToken).safeTransferFrom(msg.sender, address(this), amount)
+        let this_address = self.this_address.read();
+        let mut tf_calldata = Vec::new();
+        tf_calldata.extend_from_slice(&function_selector(b"transferFrom(address,address,uint256)"));
+        let tf_args = (from, this_address, amount);
+        tf_calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&tf_args));
+        match eth_riscv_runtime::call::call_contract(_local_token, 0, &tf_calldata, None) {
+            Ok(bytes) => {
+                // SafeERC20 semantics: if return data exists, it must decode to true
+                if !bytes.is_empty() {
+                    let ok = <bool as alloy_sol_types::SolValue>::abi_decode(&bytes).unwrap_or(false);
+                    if !ok { revert(); }
+                }
+            }
+            Err(_) => { revert(); }
+        }
+
+        // If bridged, burn on local token
+        if is_bridged {
+            let mut burn_calldata = Vec::new();
+            burn_calldata.extend_from_slice(&function_selector(b"burn(uint256)"));
+            // Single static param; abi_encode is fine
+            burn_calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode(&amount));
+            match eth_riscv_runtime::call::call_contract(_local_token, 0, &burn_calldata, None) {
+                Ok(_) => {}
+                Err(_) => { revert(); }
+            }
+        }
+
+        // signalService.sendSignal(id)
+        let sig_addr = self.signal_service.read();
+        let mut ss_calldata = Vec::with_capacity(4 + 32);
+        ss_calldata.extend_from_slice(&function_selector(b"sendSignal(bytes32)"));
+        ss_calldata.extend_from_slice(id.as_slice());
+        match eth_riscv_runtime::call::call_contract(sig_addr, 0, &ss_calldata, Some(32)) {
+            Ok(_) => {}
+            Err(_) => { revert(); }
+        }
+
+        // Emit DepositMade(id, erc20Deposit, localToken)
+        let erc20_deposit = ERC20Deposit { nonce, from, to, sourceToken: source_token, amount };
+        eth_riscv_runtime::log::emit(DepositMade { id, deposit: erc20_deposit, local_token: _local_token });
+
+        id
+    }
+
+    /// claimDeposit(ERC20Deposit, bytes proof)
+    pub fn claimDeposit(&mut self, _erc20_deposit: (U256, Address, Address, Address, U256), _proof: Bytes) {
+        let (nonce, from, to, source_token, amount) = _erc20_deposit;
+
+        // Compute id = keccak256(abi.encode(DEPOSIT_SIGNAL_PREFIX, erc20Deposit))
+        let id = self.getDepositId((nonce, from, to, source_token, amount));
+
+        // require(!processed(id))
+        if self.processed[id].read() == U256::from(1u8) { revert(); }
+
+        // signalService.verifySignal(counterpart, id, proof)
+        let counterparty = self.counterpart.read();
+        let sig_addr = self.signal_service.read();
+        let mut calldata = Vec::new();
+        calldata.extend_from_slice(&function_selector(b"verifySignal(address,bytes32,bytes)"));
+        let args = (counterparty, id, _proof.clone());
+        calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&args));
+        match eth_riscv_runtime::call::call_contract(sig_addr, 0, &calldata, None) {
+            Ok(_) => {}
+            Err(_) => { revert(); }
+        }
+
+        // Mark processed before effects to match Solidity nonReentrant semantics ordering
+        self.processed[id].write(U256::from(1u8));
+
+        // _sendERC20(erc20Deposit)
+        let counterpart = self.counterpart_token_of[source_token].read();
+        if counterpart != Address::ZERO {
+            // Mint on bridged token to recipient (msg.sender is bridge)
+            let mut mint_calldata = Vec::new();
+            mint_calldata.extend_from_slice(&function_selector(b"mint(address,uint256)"));
+            let mint_args = (to, amount);
+            mint_calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&mint_args));
+            match eth_riscv_runtime::call::call_contract(counterpart, 0, &mint_calldata, None) {
+                Ok(_) => {}
+                Err(_) => { revert(); }
+            }
+        } else {
+            // Transfer held source tokens from bridge to recipient
+            let mut t_calldata = Vec::new();
+            t_calldata.extend_from_slice(&function_selector(b"transfer(address,uint256)"));
+            let t_args = (to, amount);
+            t_calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&t_args));
+            match eth_riscv_runtime::call::call_contract(source_token, 0, &t_calldata, None) {
+                Ok(bytes) => {
+                    if !bytes.is_empty() {
+                        let ok = <bool as alloy_sol_types::SolValue>::abi_decode(&bytes).unwrap_or(false);
+                        if !ok { revert(); }
+                    }
+                }
+                Err(_) => { revert(); }
+            }
+        }
+
+        // Emit DepositClaimed(id, erc20Deposit)
+        let erc20_deposit = ERC20Deposit { nonce, from, to, sourceToken: source_token, amount };
+        eth_riscv_runtime::log::emit(DepositClaimed { id, deposit: erc20_deposit });
+    }
+}
+
+// ---------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------
+
+fn token_description_prefix() -> B32 {
+    B32::from(alloy_keccak256(b"ERC20_TOKEN_DESCRIPTION"))
+}
+
+fn deposit_prefix() -> B32 {
+    B32::from(alloy_keccak256(b"ERC20_DEPOSIT"))
+}
+
+
+/// Compute a 4-byte function selector from a signature string, e.g. b"name()".
+fn function_selector(signature: &[u8]) -> [u8; 4] {
+    let hash = alloy_keccak256(signature);
+    [hash[0], hash[1], hash[2], hash[3]]
+}
+
+/// Staticcall ERC20 name() -> Option<String>
+fn erc20_metadata_name(token: Address) -> Option<String> {
+    let mut calldata = Vec::with_capacity(4);
+    calldata.extend_from_slice(&function_selector(b"name()"));
+    match eth_riscv_runtime::call::staticcall_contract(token, 0, &calldata, None) {
+        Ok(bytes) => <String as alloy_sol_types::SolValue>::abi_decode(&bytes).ok(),
+        Err(_) => None,
+    }
+}
+
+/// Staticcall ERC20 symbol() -> Option<String>
+fn erc20_metadata_symbol(token: Address) -> Option<String> {
+    let mut calldata = Vec::with_capacity(4);
+    calldata.extend_from_slice(&function_selector(b"symbol()"));
+    match eth_riscv_runtime::call::staticcall_contract(token, 0, &calldata, None) {
+        Ok(bytes) => <String as alloy_sol_types::SolValue>::abi_decode(&bytes).ok(),
+        Err(_) => None,
+    }
+}
+
+/// Staticcall ERC20 decimals() -> Option<u8>
+fn erc20_metadata_decimals(token: Address) -> Option<u8> {
+    let mut calldata = Vec::with_capacity(4);
+    calldata.extend_from_slice(&function_selector(b"decimals()"));
+    match eth_riscv_runtime::call::staticcall_contract(token, 0, &calldata, None) {
+        Ok(bytes) => {
+            // decode as U256; take the least significant byte
+            if let Ok(v) = <U256 as alloy_sol_types::SolValue>::abi_decode(&bytes) {
+                let be = v.to_be_bytes::<32>();
+                Some(be[31])
+            } else {
+                None
+            }
+        }
+        Err(_) => None,
+    }
+}

--- a/examples/hydra-erc20-bridge/src/lib.rs
+++ b/examples/hydra-erc20-bridge/src/lib.rs
@@ -15,8 +15,8 @@
 use alloy_core::primitives::{keccak256 as alloy_keccak256, Address, Bytes, FixedBytes, U256};
 use alloy_sol_types::sol;
 use contract_derive::{contract, storage, Event};
+use eth_riscv_runtime::revert;
 use eth_riscv_runtime::types::*;
-use eth_riscv_runtime::{revert};
 
 extern crate alloc;
 use alloc::string::String;
@@ -147,7 +147,9 @@ impl ERC20Bridge {
     // Constructor
     // ---------------------------------------------------------------------
     pub fn new(signal_service: Address, counterpart: Address, _this_address: Address) -> Self {
-        if signal_service == Address::ZERO || counterpart == Address::ZERO { revert(); }
+        if signal_service == Address::ZERO || counterpart == Address::ZERO {
+            revert();
+        }
         let mut s = ERC20Bridge::default();
         s.signal_service.write(signal_service);
         s.counterpart.write(counterpart);
@@ -199,14 +201,16 @@ impl ERC20Bridge {
     ///   - SolValue trait: https://docs.rs/alloy-sol-types/1.3.1/alloy_sol_types/trait.SolValue.html
     ///   - I256: https://docs.rs/alloy-core/1.3.1/alloy_core/primitives/struct.I256.html
     ///   - U256: https://docs.rs/alloy-core/1.3.1/alloy_core/primitives/struct.U256.html
-    pub fn getTokenDescriptionId(
-        &self,
-        token_desc: (Address, String, String, u8),
-    ) -> B32 {
+    pub fn getTokenDescriptionId(&self, token_desc: (Address, String, String, u8)) -> B32 {
         let prefix = token_description_prefix();
         let (source, name, symbol, decimals) = token_desc;
         // Match Solidity: keccak256(abi.encode(prefix, TokenDescription)) where TokenDescription is a tuple param
-        let td = TokenDescription { sourceToken: source, name, symbol, decimals };
+        let td = TokenDescription {
+            sourceToken: source,
+            name,
+            symbol,
+            decimals,
+        };
         let params = (prefix, td);
         let bytes = alloy_sol_types::SolValue::abi_encode_params(&params);
         B32::from(alloy_keccak256(&bytes))
@@ -219,13 +223,12 @@ impl ERC20Bridge {
     /// For static-only inner tuples, encoding a single tuple vs. multiple params produces identical
     /// bytes. If any dynamic field is ever added here, switch to `abi_encode_params(&(prefix, erc20Deposit))`
     /// to preserve Solidity parity.
-    pub fn getDepositId(
-        &self,
-        erc20_deposit: (U256, Address, Address, Address, U256),
-    ) -> B32 {
+    pub fn getDepositId(&self, erc20_deposit: (U256, Address, Address, Address, U256)) -> B32 {
         let prefix = deposit_prefix();
         let tuple = (prefix, erc20_deposit);
-        B32::from(alloy_keccak256(&alloy_sol_types::SolValue::abi_encode(&tuple)))
+        B32::from(alloy_keccak256(&alloy_sol_types::SolValue::abi_encode(
+            &tuple,
+        )))
     }
 
     // ---------------------------------------------------------------------
@@ -235,8 +238,12 @@ impl ERC20Bridge {
     /// recordTokenDescription(address token) -> bytes32
     pub fn recordTokenDescription(&mut self, token: Address) -> B32 {
         // Parity checks
-        if token == Address::ZERO { revert(); }
-        if self.is_bridged_token[token].read() == U256::from(1u8) { revert(); }
+        if token == Address::ZERO {
+            revert();
+        }
+        if self.is_bridged_token[token].read() == U256::from(1u8) {
+            revert();
+        }
 
         // --- Read token metadata; if all three fail, mirror base revert behavior ---
         // Try/catch parity: each metadata call may fail independently; apply per-field fallbacks
@@ -248,14 +255,24 @@ impl ERC20Bridge {
         // IMPORTANT: Solidity encodes two params `(prefix, tokenDesc)`; use abi_encode_params
         let id = {
             let prefix = token_description_prefix();
-            let td = TokenDescription { sourceToken: token, name: name.clone(), symbol: symbol.clone(), decimals: decimals_u8 };
+            let td = TokenDescription {
+                sourceToken: token,
+                name: name.clone(),
+                symbol: symbol.clone(),
+                decimals: decimals_u8,
+            };
             let params = (prefix, td);
             let bytes = alloy_sol_types::SolValue::abi_encode_params(&params);
             B32::from(alloy_keccak256(&bytes))
         };
 
         // Rebuild TokenDescription to move into event payload
-        let token_desc = TokenDescription { sourceToken: token, name, symbol, decimals: decimals_u8 };
+        let token_desc = TokenDescription {
+            sourceToken: token,
+            name,
+            symbol,
+            decimals: decimals_u8,
+        };
 
         // Signal via SignalService: sendSignal(bytes32) -> bytes32 (slot)
         // Propagate revert on failure to match Solidity behavior
@@ -265,11 +282,16 @@ impl ERC20Bridge {
         calldata.extend_from_slice(id.as_slice());
         match eth_riscv_runtime::call::call_contract(sig_addr, 0, &calldata, Some(32)) {
             Ok(_) => { /* ignore returned slot */ }
-            Err(_) => { revert(); }
+            Err(_) => {
+                revert();
+            }
         }
 
         // Emit TokenDescriptionRecorded(id, tokenDesc)
-        eth_riscv_runtime::log::emit(TokenDescriptionRecorded { id, description: token_desc });
+        eth_riscv_runtime::log::emit(TokenDescriptionRecorded {
+            id,
+            description: token_desc,
+        });
 
         id
     }
@@ -284,18 +306,18 @@ impl ERC20Bridge {
         let (source_token, name, symbol, decimals_u8) = token_desc;
 
         // Compute id = keccak256(abi.encode(TOKEN_DESCRIPTION_SIGNAL_PREFIX, tokenDesc))
-        let id = self.getTokenDescriptionId((
-            source_token,
-            name.clone(),
-            symbol.clone(),
-            decimals_u8,
-        ));
+        let id =
+            self.getTokenDescriptionId((source_token, name.clone(), symbol.clone(), decimals_u8));
 
         // require(!_processed[id])
-        if self.processed[id].read() == U256::from(1u8) { revert(); }
+        if self.processed[id].read() == U256::from(1u8) {
+            revert();
+        }
 
         // require(_counterpartTokens[sourceToken] == address(0))
-        if self.counterpart_token_of[source_token].read() != Address::ZERO { revert(); }
+        if self.counterpart_token_of[source_token].read() != Address::ZERO {
+            revert();
+        }
 
         // signalService.verifySignal(counterpart, id, proof)
         // ABI: verifySignal(address,bytes32,bytes)
@@ -307,7 +329,9 @@ impl ERC20Bridge {
         calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&args));
         match eth_riscv_runtime::call::call_contract(sig_addr, 0, &calldata, None) {
             Ok(_) => {}
-            Err(_) => { revert(); }
+            Err(_) => {
+                revert();
+            }
         }
 
         // Read this_address
@@ -324,7 +348,9 @@ impl ERC20Bridge {
         .with_ctx(&mut *self);
         let deployed = child.address();
 
-        if deployed == Address::ZERO { revert(); }
+        if deployed == Address::ZERO {
+            revert();
+        }
 
         // _counterpartTokens[source] = deployed; _isBridgedTokens[deployed] = true; _processed[id] = true
         self.counterpart_token_of[source_token].write(deployed);
@@ -332,8 +358,17 @@ impl ERC20Bridge {
         self.processed[id].write(U256::from(1u8));
 
         // Emit CounterpartTokenDeployed(id, tokenDesc, deployed)
-        let td = TokenDescription { sourceToken: source_token, name, symbol, decimals: decimals_u8 };
-        eth_riscv_runtime::log::emit(CounterpartTokenDeployed { id, description: td, deployed_token: deployed });
+        let td = TokenDescription {
+            sourceToken: source_token,
+            name,
+            symbol,
+            decimals: decimals_u8,
+        };
+        eth_riscv_runtime::log::emit(CounterpartTokenDeployed {
+            id,
+            description: td,
+            deployed_token: deployed,
+        });
 
         deployed
     }
@@ -355,7 +390,7 @@ impl ERC20Bridge {
                         revert()
                     }
                 }
-                Err(_) => { revert() }
+                Err(_) => revert(),
             }
         } else {
             _local_token
@@ -372,7 +407,8 @@ impl ERC20Bridge {
         let id = self.getDepositId(deposit_tuple);
 
         // Increment nonce (unchecked in Solidity semantics)
-        self.global_deposit_nonce.write(nonce.saturating_add(U256::from(1u8)));
+        self.global_deposit_nonce
+            .write(nonce.saturating_add(U256::from(1u8)));
 
         // IERC20(localToken).safeTransferFrom(msg.sender, address(this), amount)
         let this_address = self.this_address.read();
@@ -384,11 +420,16 @@ impl ERC20Bridge {
             Ok(bytes) => {
                 // SafeERC20 semantics: if return data exists, it must decode to true
                 if !bytes.is_empty() {
-                    let ok = <bool as alloy_sol_types::SolValue>::abi_decode(&bytes).unwrap_or(false);
-                    if !ok { revert(); }
+                    let ok =
+                        <bool as alloy_sol_types::SolValue>::abi_decode(&bytes).unwrap_or(false);
+                    if !ok {
+                        revert();
+                    }
                 }
             }
-            Err(_) => { revert(); }
+            Err(_) => {
+                revert();
+            }
         }
 
         // If bridged, burn on local token
@@ -399,7 +440,9 @@ impl ERC20Bridge {
             burn_calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode(&amount));
             match eth_riscv_runtime::call::call_contract(_local_token, 0, &burn_calldata, None) {
                 Ok(_) => {}
-                Err(_) => { revert(); }
+                Err(_) => {
+                    revert();
+                }
             }
         }
 
@@ -410,25 +453,43 @@ impl ERC20Bridge {
         ss_calldata.extend_from_slice(id.as_slice());
         match eth_riscv_runtime::call::call_contract(sig_addr, 0, &ss_calldata, Some(32)) {
             Ok(_) => {}
-            Err(_) => { revert(); }
+            Err(_) => {
+                revert();
+            }
         }
 
         // Emit DepositMade(id, erc20Deposit, localToken)
-        let erc20_deposit = ERC20Deposit { nonce, from, to, sourceToken: source_token, amount };
-        eth_riscv_runtime::log::emit(DepositMade { id, deposit: erc20_deposit, local_token: _local_token });
+        let erc20_deposit = ERC20Deposit {
+            nonce,
+            from,
+            to,
+            sourceToken: source_token,
+            amount,
+        };
+        eth_riscv_runtime::log::emit(DepositMade {
+            id,
+            deposit: erc20_deposit,
+            local_token: _local_token,
+        });
 
         id
     }
 
     /// claimDeposit(ERC20Deposit, bytes proof)
-    pub fn claimDeposit(&mut self, _erc20_deposit: (U256, Address, Address, Address, U256), _proof: Bytes) {
+    pub fn claimDeposit(
+        &mut self,
+        _erc20_deposit: (U256, Address, Address, Address, U256),
+        _proof: Bytes,
+    ) {
         let (nonce, from, to, source_token, amount) = _erc20_deposit;
 
         // Compute id = keccak256(abi.encode(DEPOSIT_SIGNAL_PREFIX, erc20Deposit))
         let id = self.getDepositId((nonce, from, to, source_token, amount));
 
         // require(!processed(id))
-        if self.processed[id].read() == U256::from(1u8) { revert(); }
+        if self.processed[id].read() == U256::from(1u8) {
+            revert();
+        }
 
         // signalService.verifySignal(counterpart, id, proof)
         let counterparty = self.counterpart.read();
@@ -439,7 +500,9 @@ impl ERC20Bridge {
         calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&args));
         match eth_riscv_runtime::call::call_contract(sig_addr, 0, &calldata, None) {
             Ok(_) => {}
-            Err(_) => { revert(); }
+            Err(_) => {
+                revert();
+            }
         }
 
         // Mark processed before effects to match Solidity nonReentrant semantics ordering
@@ -452,10 +515,13 @@ impl ERC20Bridge {
             let mut mint_calldata = Vec::new();
             mint_calldata.extend_from_slice(&function_selector(b"mint(address,uint256)"));
             let mint_args = (to, amount);
-            mint_calldata.extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&mint_args));
+            mint_calldata
+                .extend_from_slice(&alloy_sol_types::SolValue::abi_encode_params(&mint_args));
             match eth_riscv_runtime::call::call_contract(counterpart, 0, &mint_calldata, None) {
                 Ok(_) => {}
-                Err(_) => { revert(); }
+                Err(_) => {
+                    revert();
+                }
             }
         } else {
             // Transfer held source tokens from bridge to recipient
@@ -466,17 +532,31 @@ impl ERC20Bridge {
             match eth_riscv_runtime::call::call_contract(source_token, 0, &t_calldata, None) {
                 Ok(bytes) => {
                     if !bytes.is_empty() {
-                        let ok = <bool as alloy_sol_types::SolValue>::abi_decode(&bytes).unwrap_or(false);
-                        if !ok { revert(); }
+                        let ok = <bool as alloy_sol_types::SolValue>::abi_decode(&bytes)
+                            .unwrap_or(false);
+                        if !ok {
+                            revert();
+                        }
                     }
                 }
-                Err(_) => { revert(); }
+                Err(_) => {
+                    revert();
+                }
             }
         }
 
         // Emit DepositClaimed(id, erc20Deposit)
-        let erc20_deposit = ERC20Deposit { nonce, from, to, sourceToken: source_token, amount };
-        eth_riscv_runtime::log::emit(DepositClaimed { id, deposit: erc20_deposit });
+        let erc20_deposit = ERC20Deposit {
+            nonce,
+            from,
+            to,
+            sourceToken: source_token,
+            amount,
+        };
+        eth_riscv_runtime::log::emit(DepositClaimed {
+            id,
+            deposit: erc20_deposit,
+        });
     }
 }
 
@@ -491,7 +571,6 @@ fn token_description_prefix() -> B32 {
 fn deposit_prefix() -> B32 {
     B32::from(alloy_keccak256(b"ERC20_DEPOSIT"))
 }
-
 
 /// Compute a 4-byte function selector from a signature string, e.g. b"name()".
 fn function_selector(signature: &[u8]) -> [u8; 4] {


### PR DESCRIPTION
**Problem**
- Event derive changes introduced compile-time failures and broke usage of the `sol!` macro in struct events ->

```rust
sol! {
    struct TokenDescription {
        // The source token address on the source chain
        address sourceToken;
        // The token name
        string name;
        // The token symbol
        string symbol;
        // The token decimals
        uint8 decimals;
    }
}

// Events (parity with Solidity)
#[derive(Event)]
struct TokenDescriptionRecorded {
    #[indexed]
    id: B32,
    description: TokenDescription,
}

...

// Emit TokenDescriptionRecorded(id, tokenDesc)
eth_riscv_runtime::log::emit(TokenDescriptionRecorded {
    id,
    description: token_desc,
});
```

**Change**
- Events: revert workaround, drop compile-time type precompute and all u8→U256 casting
- Compute event signatures at emit time from each field’s `SolValue`, and encode by borrowing (`&self.field`) to avoid moves

**Rationale**
- `sol!` structs implement `SolValue` with correct Solidity layout, including `uint8`. Runtime `sol_type_name()` and `abi_encode()` produce the correct signature and bytes

**Impact**
- The following will not compile in R55:

```
// Events (parity with Solidity)
#[derive(Event)]
struct Test {
    #[indexed]
    id: u8
}
```

- Hydra doesn't match on event signatures/logs -> I think for now its fine for us to remove the usage of `u8`/`uint8`, and only use the workaround fix for when we require parity within Hydra
