### PR TITLE
derive(Event): clone fields before encode (fix E0507)

### DIFF
--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -247,7 +247,7 @@ pub fn event_derive(input: TokenStream) -> TokenStream {
     let field_upcast_exprs: Vec<proc_macro2::TokenStream> = field_types
         .iter()
         .zip(field_names.iter())
-        .map(|(ty, name)| helpers::gen_upcast_expr(quote! { self.#name }, ty))
+        .map(|(ty, name)| helpers::gen_upcast_expr(quote! { (self.#name).clone() }, ty))
         .collect();
 
     let expanded = quote! {


### PR DESCRIPTION
**Problem**
`feat/uint8-support` broke compilation for the n = 2/r55 `ERC20Bridge` ->

```
53 | #[derive(Event)]
   |          ^^^^^ move occurs because `self.deposit.4` has type `alloy_core::alloy_primitives::Bytes`, which does not implement the `Copy` trait
```


**Solution**

Small fix, avoid moving from `&self` during event encode; encode cloned value with existing u8→U256 upcast. 

No other behavior changes

**Intended use**

```solidity
struct TokenDescription {
    // The source token address on the source chain
    address sourceToken;
    // The token name
    string name;
    // The token symbol
    string symbol;
    // The token decimals
    uint8 decimals;
}
```


```rust

// Events
#[derive(Event)]
struct TokenDescriptionRecorded {
    #[indexed]
    id: B32,
    description: (Address, String, String, u8),
}

...

// Emit TokenDescriptionRecorded
eth_riscv_runtime::log::emit(TokenDescriptionRecorded {
    id,
    description: (token, name, symbol, decimals_u8),
});
```

Events don't need to match in Hydra and this preserves use of `u8` in Events. I think just this small fix should be good for now