### PR TITLE
runtime(create): u8→U256 upcast for constructor params

### DIFF
--- a/eth-riscv-runtime/src/create.rs
+++ b/eth-riscv-runtime/src/create.rs
@@ -1,11 +1,120 @@
 extern crate alloc;
-use alloy_core::primitives::{Address, Bytes, U32};
+use alloy_core::primitives::{Address, Bytes, U32, U256};
 use alloy_sol_types::{SolType, SolValue};
 use ext_alloc::vec::Vec;
 use core::{arch::asm, marker::PhantomData, u64};
 use eth_riscv_syscalls::Syscall;
 
 use crate::{FromBuilder, InitInterface, MethodCtx, ReadWrite};
+
+// Minimal, non-invasive ABI upcast helper to mirror contract-derive's u8→U256 handling
+// for constructor argument encoding. Extend as needed.
+trait AbiUpcast {
+    type Output;
+    fn upcast(self) -> Self::Output;
+}
+
+impl AbiUpcast for u8 {
+    type Output = U256;
+    #[inline]
+    fn upcast(self) -> Self::Output {
+        U256::from(self as u64)
+    }
+}
+
+// Identity for common primitives
+impl AbiUpcast for U256 { type Output = U256; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for Address { type Output = Address; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for Bytes { type Output = Bytes; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for alloc::string::String { type Output = alloc::string::String; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for bool { type Output = bool; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u16 { type Output = u16; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u32 { type Output = u32; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u64 { type Output = u64; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for u128 { type Output = u128; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i8 { type Output = i8; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i16 { type Output = i16; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i32 { type Output = i32; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i64 { type Output = i64; #[inline] fn upcast(self) -> Self::Output { self } }
+impl AbiUpcast for i128 { type Output = i128; #[inline] fn upcast(self) -> Self::Output { self } }
+
+// Containers
+impl<T: AbiUpcast> AbiUpcast for alloc::vec::Vec<T> {
+    type Output = alloc::vec::Vec<<T as AbiUpcast>::Output>;
+    #[inline]
+    fn upcast(self) -> Self::Output {
+        self.into_iter().map(|v| v.upcast()).collect()
+    }
+}
+
+impl<T: AbiUpcast + Clone, const N: usize> AbiUpcast for [T; N] {
+    type Output = [<T as AbiUpcast>::Output; N];
+    #[inline]
+    fn upcast(self) -> Self::Output {
+        core::array::from_fn(|i| self[i].clone().upcast())
+    }
+}
+
+// Tuple upcasts (cover common arities used by constructors)
+impl<A: AbiUpcast> AbiUpcast for (A,) {
+    type Output = (A::Output,);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(),) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast> AbiUpcast for (A, B) {
+    type Output = (A::Output, B::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast> AbiUpcast for (A, B, C) {
+    type Output = (A::Output, B::Output, C::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast> AbiUpcast for (A, B, C, D) {
+    type Output = (A::Output, B::Output, C::Output, D::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast> AbiUpcast for (A, B, C, D, E) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast> AbiUpcast for (A, B, C, D, E, F) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast, H: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G, H) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output, H::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast, H: AbiUpcast, I: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G, H, I) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output, H::Output, I::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast(), self.8.upcast()) }
+}
+
+impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: AbiUpcast, G: AbiUpcast, H: AbiUpcast, I: AbiUpcast, J: AbiUpcast> AbiUpcast for (A, B, C, D, E, F, G, H, I, J) {
+    type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output, G::Output, H::Output, I::Output, J::Output);
+    #[inline]
+    fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast(), self.8.upcast(), self.9.upcast()) }
+}
 
 pub trait Deployable {
     type Interface: InitInterface;
@@ -19,10 +128,10 @@ pub trait Deployable {
     }
 
     // Creates a deployment builder that captures the constructor args
-    fn deploy<Args>(args: Args) -> DeploymentBuilder<Self, Args> 
-    where 
+    fn deploy<Args>(args: Args) -> DeploymentBuilder<Self, Args>
+    where
         Self: Sized,
-        Args: SolValue + core::convert::From<<<Args as SolValue>::SolType as SolType>::RustType>
+        Args: AbiUpcast,
     {
         DeploymentBuilder {
             args,
@@ -31,17 +140,17 @@ pub trait Deployable {
     } 
 }
 
-pub struct DeploymentBuilder<D: Deployable + ?Sized, Args> 
+pub struct DeploymentBuilder<D: Deployable + ?Sized, Args>
 where
-    Args: SolValue + core::convert::From<<<Args as SolValue>::SolType as SolType>::RustType>
+    Args: AbiUpcast,
 {
     args: Args,
     _phantom: PhantomData<D>,
 }
 
-impl<D: Deployable, Args> DeploymentBuilder<D, Args> 
+impl<D: Deployable, Args> DeploymentBuilder<D, Args>
 where
-    Args: SolValue + core::convert::From<<<Args as SolValue>::SolType as SolType>::RustType>
+    Args: AbiUpcast,
 {
 
     /// Return the interface with the appropriate context.
@@ -50,16 +159,19 @@ where
     /// - Encodes constructor args using Solidity params-encoding (`abi.encode(a,b,...)`).
     /// - For single-arg constructors, pass a 1-tuple `(arg,)` so the encoder treats it
     ///   as a parameter list; this is critical for dynamic types (string/bytes) parity.
-    pub fn with_ctx<M, T>(self, ctx: M) -> T 
+    pub fn with_ctx<M, T>(self, ctx: M) -> T
     where
         M: MethodCtx<Allowed = ReadWrite>, // Constrain to mutable contexts only
         D::Interface: InitInterface,
         T: FromBuilder<Context = M::Allowed>,
         D::Interface: crate::IntoInterface<T>,
-        for<'a> <<Args as SolValue>::SolType as SolType>::Token<'a>: alloy_sol_types::abi::TokenSeq<'a>
+        for<'a> << <Args as AbiUpcast>::Output as SolValue>::SolType as SolType>::Token<'a>: alloy_sol_types::abi::TokenSeq<'a>,
+        <Args as AbiUpcast>::Output: SolValue,
     {
         let deploy_bin = D::__runtime();
-        let encoded_args = self.args.abi_encode_params();
+        // Upcast nested u8s to U256 before ABI params encoding
+        let upcast_args = self.args.upcast();
+        let encoded_args = upcast_args.abi_encode_params();
 
         // Craft R55 initcode expected by r55-evm:
         // [4-byte codesize][deploy_bin (starts with 0xFF)][constructor_args]

--- a/eth-riscv-runtime/src/create.rs
+++ b/eth-riscv-runtime/src/create.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
-use alloy_core::primitives::{Address, Bytes, U32, U256};
+use alloc::string::String;
+use alloy_core::primitives::{Address, Bytes, U32, U256, I256, FixedBytes};
 use alloy_sol_types::{SolType, SolValue};
 use ext_alloc::vec::Vec;
 use core::{arch::asm, marker::PhantomData, u64};
@@ -8,35 +9,38 @@ use eth_riscv_syscalls::Syscall;
 use crate::{FromBuilder, InitInterface, MethodCtx, ReadWrite};
 
 // Minimal, non-invasive ABI upcast helper to mirror contract-derive's u8→U256 handling
-// for constructor argument encoding. Extend as needed.
+// for constructor argument encoding.
+//
+// Encoding semantics:
+// - bytes (dynamic): use `Bytes` (or `&Bytes`).
+// - uint8[] (dynamic): `Vec<u8>` / `&[u8]` → `Vec<U256>` (element-wise upcast).
+// - fixed arrays: `[T; N]` → `[T::Output; N]` via element upcast (e.g., `[u8; N]` → `[U256; N]`).
+// - bytesN (fixed): pass `FixedBytes<N>` to encode as a single 32-byte word.
+// - tuples: supported up to arity 10.
+// - borrowed forms: `&T`, `&str`, `&[T]` supported without forcing ownership.
+// - single-arg constructors: pass as a 1‑tuple `(arg,)` to use params encoding.
 trait AbiUpcast {
     type Output;
     fn upcast(self) -> Self::Output;
+}
+
+macro_rules! impl_identity_upcast {
+    ($($t:ty),+ $(,)?) => {$(
+        impl AbiUpcast for $t { type Output = $t; #[inline] fn upcast(self) -> Self::Output { self } }
+    )+}
 }
 
 impl AbiUpcast for u8 {
     type Output = U256;
     #[inline]
     fn upcast(self) -> Self::Output {
-        U256::from(self as u64)
+        U256::from(self)
     }
 }
 
-// Identity for common primitives
-impl AbiUpcast for U256 { type Output = U256; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for Address { type Output = Address; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for Bytes { type Output = Bytes; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for alloc::string::String { type Output = alloc::string::String; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for bool { type Output = bool; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u16 { type Output = u16; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u32 { type Output = u32; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u64 { type Output = u64; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for u128 { type Output = u128; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i8 { type Output = i8; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i16 { type Output = i16; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i32 { type Output = i32; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i64 { type Output = i64; #[inline] fn upcast(self) -> Self::Output { self } }
-impl AbiUpcast for i128 { type Output = i128; #[inline] fn upcast(self) -> Self::Output { self } }
+// Identity upcasts
+impl_identity_upcast!(U256, I256, Address, Bytes, String, bool, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+impl<const N: usize> AbiUpcast for FixedBytes<N> { type Output = FixedBytes<N>; #[inline] fn upcast(self) -> Self::Output { self } }
 
 // Containers
 impl<T: AbiUpcast> AbiUpcast for alloc::vec::Vec<T> {
@@ -47,15 +51,45 @@ impl<T: AbiUpcast> AbiUpcast for alloc::vec::Vec<T> {
     }
 }
 
+// Borrowed forms to avoid forcing ownership at call sites
+impl<'a, T> AbiUpcast for &'a T
+where
+    T: AbiUpcast + Clone,
+{
+    type Output = <T as AbiUpcast>::Output;
+    #[inline]
+    fn upcast(self) -> Self::Output { self.clone().upcast() }
+}
+
+impl<'a> AbiUpcast for &'a str {
+    type Output = String;
+    #[inline]
+    fn upcast(self) -> Self::Output { String::from(self) }
+}
+
+impl<'a, T> AbiUpcast for &'a [T]
+where
+    T: AbiUpcast + Clone,
+{
+    type Output = Vec<<T as AbiUpcast>::Output>;
+    #[inline]
+    fn upcast(self) -> Self::Output { self.iter().cloned().map(|v| v.upcast()).collect() }
+}
+
+// Fixed-size arrays: element-wise upcast
 impl<T: AbiUpcast + Clone, const N: usize> AbiUpcast for [T; N] {
     type Output = [<T as AbiUpcast>::Output; N];
     #[inline]
     fn upcast(self) -> Self::Output {
-        core::array::from_fn(|i| self[i].clone().upcast())
+        let arr = self;
+        core::array::from_fn(|i| arr[i].clone().upcast())
     }
 }
 
-// Tuple upcasts (cover common arities used by constructors)
+// Unit tuple for zero-arg constructors
+impl AbiUpcast for () { type Output = (); #[inline] fn upcast(self) -> Self::Output { self } }
+
+// Tuple upcasts (cover common arities used by constructors; limited to 10)
 impl<A: AbiUpcast> AbiUpcast for (A,) {
     type Output = (A::Output,);
     #[inline]
@@ -116,6 +150,7 @@ impl<A: AbiUpcast, B: AbiUpcast, C: AbiUpcast, D: AbiUpcast, E: AbiUpcast, F: Ab
     fn upcast(self) -> Self::Output { (self.0.upcast(), self.1.upcast(), self.2.upcast(), self.3.upcast(), self.4.upcast(), self.5.upcast(), self.6.upcast(), self.7.upcast(), self.8.upcast(), self.9.upcast()) }
 }
 
+
 pub trait Deployable {
     type Interface: InitInterface;
 
@@ -169,7 +204,7 @@ where
         <Args as AbiUpcast>::Output: SolValue,
     {
         let deploy_bin = D::__runtime();
-        // Upcast nested u8s to U256 before ABI params encoding
+        // Upcast nested u8 to U256 and preserve shapes (Vec/tuples/[u8;N]) before ABI params encoding
         let upcast_args = self.args.upcast();
         let encoded_args = upcast_args.abi_encode_params();
 


### PR DESCRIPTION
**Problem**

Prior behavior in runtime deployment encoded constructor args directly via `abi_encode_params()` on a generic `Args` input:
```rust
// Before
where
  Args: SolValue + From<<<Args as SolValue>::SolType as SolType>::RustType>
{
  ...
  let encoded_args = self.args.abi_encode_params();
}
```
Relies on Alloy’s `SolValue` being implemented for the exact, nested Rust type of `Args` (including tuples, arrays, and vectors). Two issues:
  - Alloy cannot encode/decode `uint8` directly. Any presence of `u8` inside `Args` (`(String, u8)`, `Vec<u8>`) causes an abi_encode failure
  - Generic tuples provide no mechanism to selectively transform inner leaves before encoding; the old trait bound (`Args: SolValue`) offered no path to coerce `u8`→`U256` while preserving outer shape

Net effect:

`Deployable::deploy(args).with_ctx(ctx)` could not compile, `abi_encode_params()` would fail at runtime/build-time as soon as any `u8`-containing input was present


**Solution**

Replaced the “encode whatever `Args` is” approach with an explicit, recursive upcast step:
  - Introduced `AbiUpcast` to transform `Args` into `Args::Output` by walking tuples, arrays, vectors, and slices, converting every `u8` leaf to `U256` while preserving the outer shape
  - Then we call `abi_encode_params()` on `Args::Output`, which Alloy can encode because it no longer contains unsupported `uint8` leaves

Matches `uint8` policy in macros; naive/simple solution, contracts compile

**Intended Use**

```rust
// Deploy bridged token using R55 Deployable builder (intentionally using R55 bytecode)
let child = BridgedERC20::deploy((
    name.clone(),
    symbol.clone(),
    decimals_u8,
    source_token,
    this_address,
))
.with_ctx(&mut *self);
let deployed = child.address();

...
/// BridgedERC20 
pub fn new(name: String, symbol: String, decimals: u8, source_token: Address, erc20_bridge: Address) -> Self {
    let mut erc20 = BridgedERC20::default();
```