### PR TITLE
contract-derive: support function overloading via __overloadN normalization; selectors use canonical external names

### DIFF
--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -45,6 +45,17 @@ impl<'a> MethodInfo<'a> {
     }
 }
 
+// Return external ABI name by stripping a trailing "__overload<digits>" suffix if present.
+fn canonicalize_external_name(ident: &str) -> String {
+    if let Some(idx) = ident.rfind("__overload") {
+        let suffix = &ident[(idx + "__overload".len())..];
+        if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+            return ident[..idx].to_string();
+        }
+    }
+    ident.to_string()
+}
+
 // Helper function to get the parameter names + types of a method
 fn get_arg_props<'a>(
     skip_first_arg: bool,
@@ -682,19 +693,13 @@ pub fn gen_downcast_expr(var: TokenStream, ty: &Type) -> TokenStream {
     }
 }
 
-// Helper function to generate fn selector
+// Helper: compute 4-byte selector using canonical external name and canonical param types.
 pub fn generate_fn_selector(
     method: &MethodInfo,
     style: Option<InterfaceNamingStyle>,
 ) -> Option<[u8; 4]> {
-    // Normalize Rust ident by stripping a trailing "__overload<digits>" overload suffix, if present.
-    let mut base = method.name.to_string();
-    if let Some(idx) = base.rfind("__overload") {
-        let suffix = &base[(idx + "__overload".len())..];
-        if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
-            base.truncate(idx);
-        }
-    }
+    // Normalize to canonical external name
+    let base = canonicalize_external_name(&method.name.to_string());
     let name = match style {
         None => base,
         Some(style) => match style {
@@ -1317,6 +1322,29 @@ mod tests {
                 signature
             );
         }
+    }
+
+    #[test]
+    fn test_fn_selector_erc721_overload_plain_three_args() {
+        // Plain three-arg overload without relying on any suffix
+        let method = MockMethod::new(
+            "safeTransferFrom",
+            vec!["from: Address", "to: Address", "tokenId: U256"],
+        );
+        assert_eq!(
+            generate_fn_selector(&method.info(), None).unwrap(),
+            get_selector_from_sig("safeTransferFrom(address,address,uint256)")
+        );
+
+        // Plain four-arg overload without relying on any suffix
+        let method = MockMethod::new(
+            "safeTransferFrom",
+            vec!["from: Address", "to: Address", "tokenId: U256", "data: Bytes"],
+        );
+        assert_eq!(
+            generate_fn_selector(&method.info(), None).unwrap(),
+            get_selector_from_sig("safeTransferFrom(address,address,uint256,bytes)")
+        );
     }
 
     #[test]

--- a/contract-derive/src/helpers.rs
+++ b/contract-derive/src/helpers.rs
@@ -687,10 +687,18 @@ pub fn generate_fn_selector(
     method: &MethodInfo,
     style: Option<InterfaceNamingStyle>,
 ) -> Option<[u8; 4]> {
+    // Normalize Rust ident by stripping a trailing "__overload<digits>" overload suffix, if present.
+    let mut base = method.name.to_string();
+    if let Some(idx) = base.rfind("__overload") {
+        let suffix = &base[(idx + "__overload".len())..];
+        if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+            base.truncate(idx);
+        }
+    }
     let name = match style {
-        None => method.name.to_string(),
+        None => base,
         Some(style) => match style {
-            InterfaceNamingStyle::CamelCase => to_camel_case(method.name.to_string()),
+            InterfaceNamingStyle::CamelCase => to_camel_case(base),
         },
     };
 
@@ -1309,6 +1317,19 @@ mod tests {
                 signature
             );
         }
+    }
+
+    #[test]
+    fn test_fn_selector_overload_suffix_stripped() {
+        // When the Rust ident carries an overload suffix, it should be stripped for selector naming
+        let method = MockMethod::new(
+            "safeTransferFrom__overload1",
+            vec!["from: Address", "to: Address", "tokenId: U256"],
+        );
+        assert_eq!(
+            generate_fn_selector(&method.info(), None).unwrap(),
+            get_selector_from_sig("safeTransferFrom(address,address,uint256)")
+        );
     }
 
     #[test]

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 use alloy_core::primitives::U256;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
+use std::collections::HashMap;
 use syn::{
     parse_macro_input, Data, DeriveInput, Fields, ImplItem, ImplItemMethod,
     ItemImpl, ItemTrait, ReturnType, TraitItem,
@@ -328,7 +329,8 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let mut constructor = None;
-    let mut public_methods: Vec<&ImplItemMethod> = Vec::new();
+    // Work with owned methods so we can rename duplicates safely
+    let mut public_methods_owned: Vec<ImplItemMethod> = Vec::new();
 
     // Iterate over the items in the impl block to find pub methods + constructor
     for item in input.items.iter() {
@@ -336,10 +338,23 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
             if method.sig.ident == "new" {
                 constructor = Some(method);
             } else if let syn::Visibility::Public(_) = method.vis {
-                public_methods.push(method);
+                public_methods_owned.push(method.clone());
             }
         }
     }
+
+    // Rename duplicate idents in emitted methods: <base>__overload<n>
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for m in public_methods_owned.iter_mut() {
+        let base = m.sig.ident.to_string();
+        let entry = counts.entry(base.clone()).or_insert(0);
+        if *entry > 0 {
+            let new_ident = format_ident!("{}__overload{}", base, *entry);
+            m.sig.ident = new_ident;
+        }
+        *entry += 1;
+    }
+    let public_methods: Vec<&ImplItemMethod> = public_methods_owned.iter().collect();
 
     let input_methods: Vec<_> = public_methods
         .iter()

--- a/contract-derive/src/lib.rs
+++ b/contract-derive/src/lib.rs
@@ -344,6 +344,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     // Rename duplicate idents in emitted methods: <base>__overload<n>
+    // Overload normalization details live in helpers::generate_fn_selector (see helpers.rs).
     let mut counts: HashMap<String, usize> = HashMap::new();
     for m in public_methods_owned.iter_mut() {
         let base = m.sig.ident.to_string();


### PR DESCRIPTION
**Problem**
- Rust forbids duplicate method names in an impl
- Solidity relies on ABI overloading (same name, different params)
- ERC-721 requires both `safeTransferFrom(address,address,uint256)` and `safeTransferFrom(address,address,uint256,bytes)`

**Solution**
- Internal-only rename: when duplicate public methods exist, the macro renames subsequent Rust symbols to `<base>__overloadN`. This is not visible at the ABI
- Canonical selectors: when computing selectors, a trailing `__overload<digits>` is stripped so we hash the canonical signature `<base>(<types>)`. Dispatcher and interface both use this path

**Impact / Scope**
- Files: `r55/contract-derive/src/lib.rs`, `r55/contract-derive/src/helpers.rs`
- External ABI: unchanged. Selectors match Solidity
- User/Developer action: none. Overloads in Rust will now work when parameter lists differ, no additional attributes required

**How it works (brief)**
- Macro pass:
  - Detect duplicate pub method idents; rewrite to `<base>__overloadN` in generated Rust only
- Selector generation:
  - Strip a trailing `__overload<digits>` if present
  - Derive canonical Solidity types from Rust types; hash `<name>(<types>)`

**Example**
```rust
#[contract]
impl ERC721 {
    pub fn safeTransferFrom(&mut self, from: Address, to: Address, id: U256) { /* ... */ }
    pub fn safeTransferFrom(&mut self, from: Address, to: Address, id: U256, data: Bytes) { /* ... */ }
}
```
Both methods compile; external selectors are identical to Solidity.

**Risks / Limitations**
- Two methods with identical canonical signatures collide when compiling. This matches Solidity semantics; intentionally not guarded