### PR TITLE
syscalls/runtime: add EXTCODESIZE (0x3B) and code_size/is_contract

### DIFF
--- a/eth-riscv-runtime/src/call.rs
+++ b/eth-riscv-runtime/src/call.rs
@@ -194,7 +194,7 @@ pub fn code_size(addr: Address) -> u64 {
     size
 }
 
-/// Returns true if the address has code (i.e., is a contract).
+/// Returns true if the address has code
 pub fn has_code(addr: Address) -> bool {
     code_size(addr) > 0
 }

--- a/eth-riscv-runtime/src/call.rs
+++ b/eth-riscv-runtime/src/call.rs
@@ -176,3 +176,25 @@ pub fn return_data_copy(dest_offset: u64, res_offset: u64, res_size: u64) {
         );
     }
 }
+
+/// Returns the size of the code at the given address (EXTCODESIZE).
+pub fn code_size(addr: Address) -> u64 {
+    // Convert address → 256-bit word using the same pattern as call/staticcall
+    let word: U256 = addr.into_word().into();
+    let limbs = word.as_limbs();
+    let size: u64;
+    unsafe {
+        asm!(
+            "ecall",
+            in("a0") limbs[0], in("a1") limbs[1], in("a2") limbs[2],
+            in("t0") u8::from(Syscall::ExtCodeSize),
+            lateout("a0") size,
+        );
+    }
+    size
+}
+
+/// Returns true if the address has code (i.e., is a contract).
+pub fn is_contract(addr: Address) -> bool {
+    code_size(addr) > 0
+}

--- a/eth-riscv-runtime/src/call.rs
+++ b/eth-riscv-runtime/src/call.rs
@@ -195,6 +195,6 @@ pub fn code_size(addr: Address) -> u64 {
 }
 
 /// Returns true if the address has code (i.e., is a contract).
-pub fn is_contract(addr: Address) -> bool {
+pub fn has_code(addr: Address) -> bool {
     code_size(addr) > 0
 }

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -59,6 +59,7 @@ macro_rules! syscalls {
 // t0: 0x33, opcode for caller, returns an address
 // t0: 0x34, opcode for callvalue, a0: first limb, a1: second limb, a2: third limb, a3: fourth limb, returns 256-bit value
 // t0: 0x3A, opcode for gasprice, returns 256-bit value
+// t0: 0x3B, opcode for extcodesize, a0-a2: address, returns 64-bit size in a0
 // t0: 0x3d, opcode for returndatasize, returns 64-bit value
 // t0: 0x3e, opcode for returndatacopy, a0: memory offset, a1: return data offset, a2: return data size, returns nothing
 // t0: 0x54, opcode for sload, a0: storage key, returns 256-bit value
@@ -81,6 +82,7 @@ syscalls!(
     (0x33, Caller, "caller"),
     (0x34, CallValue, "callvalue"),
     (0x3A, GasPrice, "gasprice"),
+    (0x3B, ExtCodeSize, "extcodesize"),
     (0x3D, ReturnDataSize, "returndatasize"),
     (0x3E, ReturnDataCopy, "returndatacopy"),
     (0x42, Timestamp, "timestamp"),


### PR DESCRIPTION
**Context**

R55 contracts run as small programs that ask the EVM host to do things (storage reads, calls, logs). These “asks” are standardized calls we call syscalls. This PR adds one missing building block: a way for R55 contracts to ask “does this address have code, and if so, how big is it?”. In EVM terms, that’s `EXTCODESIZE`

This matters for patterns like ERC‑721 safe transfers, where you must detect contracts and call onERC721Received while skipping EOAs.

**Problem**
- We couldn’t tell from inside an R55 contract whether an address is a contract (non‑zero code length) or an EOA (zero)
- Without this, safe transfer flows would result in an obvious `ExecutionLogMismatch` in Hydra

**Solution** (high-level)
- Expose the `EXTCODESIZE` ability to R55 contracts:
  - Add a named syscall “extcodesize” that returns the code size of an address
  - Provide two simple runtime helpers so contract authors don’t think about low‑level details:
    - `code_size(Address)` -> `u64`
    - `is_contract(Address)` -> `bool (true if code_size > 0)`

Contracts can now write:

```rust
if eth_riscv_runtime::is_contract(to) {
    // Perform ERC721Receiver check
}
```

**Impact/Scope**
- Affected files only:
  - `r55/eth-riscv-syscalls/src/lib.rs`
    - Declares a new syscall: `ExtCodeSize` with EVM opcode `0x3B`
  - `r55/eth-riscv-runtime/src/call.rs`
    - Adds `code_size(Address) -> u64` and `is_contract(Address) -> bool` that use the syscall under the hood

No other files change in this PR. The executor wiring and gas accounting live in the stack repo and will be handled in a separate PR (see “Executor note” below).

---

**How it works (end-to-end)**
- In your r55 program, you call `is_contract(addr)`
- The runtime helper converts the address into the standard 256‑bit form and asks the host for `EXTCODESIZE`
- The executor (in the stack repo) receives that request, looks up the account’s code, and returns how many bytes it has
- `is_contract(addr)` returns true if the size is greater than 0
- Tried to mirror EVM semantics


**Gas semantics (executor note)**
- Proper warm/cold access charging for EXTCODESIZE will be implemented in the r55-evm executor (stack repo) in a follow‑up PR. This PR only adds the syscall surface and the runtime helpers
- Accurate gas metering depends on the executor follow‑up