### PR TITLE
syscalls/runtime: add GAS (0x5A) + `gas_left()` helper

### DIFF
--- a/eth-riscv-runtime/src/lib.rs
+++ b/eth-riscv-runtime/src/lib.rs
@@ -122,6 +122,16 @@ pub fn msg_value() -> U256 {
     U256::from_limbs([first, second, third, fourth])
 }
 
+/// Returns the remaining gas available for the current execution frame.
+/// Corresponds to the EVM `GAS` opcode (0x5A), exposed as `gasleft()` in Solidity.
+pub fn gas_left() -> u64 {
+    let remaining: u64;
+    unsafe {
+        asm!("ecall", lateout("a0") remaining, in("t0") u8::from(Syscall::GasLeft));
+    }
+    remaining
+}
+
 pub fn msg_sig() -> [u8; 4] {
     let sig = unsafe { slice_from_raw_parts(CALLDATA_ADDRESS + 8, 4) };
     sig.try_into().unwrap()

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -64,6 +64,7 @@ macro_rules! syscalls {
 // t0: 0x3e, opcode for returndatacopy, a0: memory offset, a1: return data offset, a2: return data size, returns nothing
 // t0: 0x54, opcode for sload, a0: storage key, returns 256-bit value
 // t0: 0x55, opcode for sstore, a0-a3: 256-bit storage key, a4-a7: 256-bit storage value, returns nothing
+// t0: 0x5A, opcode for gas (gasleft), returns 64-bit remaining gas in a0
 // t0: 0xf0, opcode for create, args: a0: 64-bit value, a1: calldata offset, a2: calldata size, returns an address
 // t0: 0xf1, opcode for call, args: a0-a2: address, a3: 64-bit value, a4: calldata offset, a5: calldata size
 // t0: 0xfa, opcode for staticcall, args: a0-a2: address, a3: 64-bit value, a4: calldata offset, a5: calldata size
@@ -92,6 +93,7 @@ syscalls!(
     (0x48, BaseFee, "basefee"),
     (0x54, SLoad, "sload"),
     (0x55, SStore, "sstore"),
+    (0x5A, GasLeft, "gasleft"),
     (0xf0, Create, "create"),
     (0xf1, Call, "call"),
     (0xfa, StaticCall, "staticcall"),


### PR DESCRIPTION
**Context**

Similar to: https://github.com/sam-iamm/r55/pull/20

R55 needs `GAS (0x5A)` for Hydra parity. `MessageRelayer.sol` uses `gasleft()` to enforce EIP-150 limits on forwarded gas:

https://github.com/Firewall-eng/stack/blob/edd234c9321664cfd52ee2cbe729bb472946efeb/contracts/src/l2/MessageRelayer.sol#L93

```solidity
  if (gasLimit == 0) {
      (ok,) = to.call{value: valueToSend}(data);
  } else {
      // EIP-150: Only 63/64 of gas can be forwarded to external calls.
      // Check against actual forwardable gas with buffer for operations before the call.
      uint256 maxForwardableGas = (gasleft() - BUFFER) * 63 / 64;
      require(gasLimit <= maxForwardableGas, InsufficientGas());
      (ok,) = to.call{value: valueToSend, gas: gasLimit}(data);
  }
  require(ok, MessageForwardingFailed());
```

Revert path in this code flow requires the R55 side to use the same `gasleft()` check to enforce the EIP-150 gas limit validation before forwarding.

**Problem**

R55 contracts can't query remaining gas, so they can't replicate the EIP-150 gas forwarding check in `MessageRelayer` (`contracts/src/l2/MessageRelayer.sol`)

**Solution**

- Add `GAS` syscall (`0x5A`) and expose `gas_left() -> u64` helper in the runtime. Contracts can now check remaining gas before forwarding
- Follows same implementation pattern as `EXTCODESIZE`

**Impact/Scope**

- `r55/eth-riscv-syscalls/src/lib.rs`: Adds `GasLeft` syscall with opcode `0x5A`
- `r55/eth-riscv-runtime/src/lib.rs`: Adds `gas_left()` helper
- Developers can now query the remaining gas from inside their R55 program

**r55-evm**: Executor wiring (`stack/crates/evm/r55-evm/src/exec/core.rs`) and gas accounting will be handled in a follow-up PR in the stack repo

---

**How it works (end-to-end)**

- R55 Program calls `gas_left()`
- Runtime makes syscall to host for GAS opcode
- Executor returns remaining gas after accounting for the GAS opcode cost
- Helper returns the value as `u64`

Matches EVM semantics: returns gas remaining after the GAS opcode itself