### PR TITLE
fix: deployable.rs path generation with dynamic pathdiff

### DIFF
--- a/r55-compile/Cargo.toml
+++ b/r55-compile/Cargo.toml
@@ -13,6 +13,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 glob = "0.3"
+pathdiff = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 syn = { version = "1.0", features = ["full"] }
 toml = "0.8"

--- a/r55-compile/src/deployable.rs
+++ b/r55-compile/src/deployable.rs
@@ -1,9 +1,30 @@
 use std::fs;
+use std::path::PathBuf;
 use tracing::info;
 
 use crate::compile::ContractWithDeps;
 
-pub fn generate_deployable(contract: &ContractWithDeps) -> eyre::Result<()> {
+pub fn generate_deployable(contract: &ContractWithDeps, output_dir: &PathBuf) -> eyre::Result<()> {
+    // Calculate relative path from contract's src/ directory to output directory
+    // pathdiff::diff_paths(target, base) returns the relative path from 'base' to 'target'
+    // We need both paths to be absolute for pathdiff to work correctly
+    let contract_src_dir = contract.path.join("src");
+    
+    // Canonicalize paths to ensure they're absolute and resolved (handles symlinks, etc.)
+    // Note: output_dir is created in main.rs before this is called, so it should exist
+    let contract_src_dir = contract_src_dir
+        .canonicalize()
+        .or_else(|_| Ok::<PathBuf, std::io::Error>(contract_src_dir.clone()))?;
+    let output_dir_canonical = output_dir
+        .canonicalize()
+        .or_else(|_| Ok::<PathBuf, std::io::Error>(output_dir.clone()))?;
+    
+    let relative_path = pathdiff::diff_paths(&output_dir_canonical, &contract_src_dir)
+        .ok_or_else(|| eyre::eyre!("Failed to calculate relative path from {:?} to {:?}. Paths may be on different drives or have no common ancestor.", contract_src_dir, output_dir))?;
+    
+    // Convert to string with forward slashes (works on all platforms for include_bytes!)
+    let relative_path_str = relative_path.to_string_lossy().replace('\\', "/");
+
     // Generate the file content
     let mut content = String::new();
 
@@ -29,8 +50,8 @@ pub fn generate_deployable(contract: &ContractWithDeps) -> eyre::Result<()> {
         // Convert dependency name to uppercase for the constant name
         let const_name = dep.name.ident.to_uppercase();
         content.push_str(&format!(
-            "const {}_BYTECODE: &'static [u8] = include_bytes!(\"../../../r55-output-bytecode/{}.bin\");\n", 
-            const_name, dep.name.package
+            "const {}_BYTECODE: &'static [u8] = include_bytes!(\"{}/{}.bin\");\n", 
+            const_name, relative_path_str, dep.name.package
         ));
     }
     content.push('\n');

--- a/r55-compile/src/main.rs
+++ b/r55-compile/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> eyre::Result<()> {
     // Generate deployable files for the dependencies
     if let Some(contracts_with_deps) = contracts.get(&false) {
         for c in contracts_with_deps {
-            generate_deployable(c)?;
+            generate_deployable(c, &output_dir)?;
         }
     }
 

--- a/r55up
+++ b/r55up
@@ -169,7 +169,7 @@ build_from_source() {
 
     # Clone repository
     log_info "Cloning repository..."
-    git clone -b fix/deployable-paths "https://github.com/$REPO_OWNER/$REPO_NAME.git"
+    git clone "https://github.com/$REPO_OWNER/$REPO_NAME.git"
     cd "$REPO_NAME"
 
     # Build the binary

--- a/r55up
+++ b/r55up
@@ -169,7 +169,7 @@ build_from_source() {
 
     # Clone repository
     log_info "Cloning repository..."
-    git clone "https://github.com/$REPO_OWNER/$REPO_NAME.git"
+    git clone -b fix/deployable-paths "https://github.com/$REPO_OWNER/$REPO_NAME.git"
     cd "$REPO_NAME"
 
     # Build the binary


### PR DESCRIPTION
**Problem**
- In `r55-compile::deployable.rs`, it hardcodes a path `../../../r55-output-bytecode/` for the `include_bytes!` macro
- Compilation for R55 programs that required `mod deployable;` only worked when running from r55 repo root (ERC20Bridge and ERC721Bridge)
- Failed from other locations (`stack/contracts/hydra-program`) with "file not found" errors

**Solution**
- Added `pathdiff` crate to dynamically calculate relative path from contract's `src/` to output directory
- Updated `generate_deployable()` to accept `output_dir` parameter
- Paths are canonicalized before calculation

**Impact**
- Isolated, `r55-compile` now works from any directory structure
- Backward compatible with existing r55 repo layout
- Note: `r55up` contains temporary `-b fix/deployable-paths` for testing—remove before merge