### PR TITLE
syscalls/runtime: add `Address` syscall (0x30) + helper

### DIFF
--- a/eth-riscv-runtime/src/tx.rs
+++ b/eth-riscv-runtime/src/tx.rs
@@ -26,3 +26,24 @@ pub fn origin() -> Address {
     bytes[16..20].copy_from_slice(&third.to_be_bytes()[..4]);
     Address::from_slice(&bytes)
 }
+
+/// Returns the address of the currently executing account (EVM `ADDRESS`, 0x30).
+pub fn address() -> Address {
+    let first: u64;
+    let second: u64;
+    let third: u64;
+    unsafe {
+        asm!(
+            "ecall",
+            lateout("a0") first,
+            lateout("a1") second,
+            lateout("a2") third,
+            in("t0") u8::from(Syscall::Address)
+        );
+    }
+    let mut bytes = [0u8; 20];
+    bytes[0..8].copy_from_slice(&first.to_be_bytes());
+    bytes[8..16].copy_from_slice(&second.to_be_bytes());
+    bytes[16..20].copy_from_slice(&third.to_be_bytes()[..4]);
+    Address::from_slice(&bytes)
+}

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -55,6 +55,7 @@ macro_rules! syscalls {
 // as described on https://www.evm.codes.
 //
 // t0: 0x20, opcode for keccak256, a0: offset, a1: size, returns keccak256 hash
+// t0: 0x30, opcode for address, returns an address
 // t0: 0x32, opcode for origin, returns an address
 // t0: 0x33, opcode for caller, returns an address
 // t0: 0x34, opcode for callvalue, a0: first limb, a1: second limb, a2: third limb, a3: fourth limb, returns 256-bit value
@@ -67,7 +68,7 @@ macro_rules! syscalls {
 // t0: 0x5A, opcode for gas (gasleft), returns 64-bit remaining gas in a0
 // t0: 0xf0, opcode for create, args: a0: 64-bit value, a1: calldata offset, a2: calldata size, returns an address
 // t0: 0xf1, opcode for call, args: a0-a2: address, a3: 64-bit value, a4: calldata offset, a5: calldata size
-// t0: 0xf4, opcode for delegatecall, args: a0-a2: address, a3: MUST be 0, a4: calldata offset, a5: calldata size
+// t0: 0xf4, opcode for delegatecall, args: a0-a2: address, a3: unused, a4: calldata offset, a5: calldata size
 // t0: 0xfa, opcode for staticcall, args: a0-a2: address, a3: 64-bit value, a4: calldata offset, a5: calldata size
 // t0: 0xf3, opcode for return, a0: memory address of data, a1: length of data in bytes, doesn't return
 // t0: 0xfd, opcode for revert, doesn't return
@@ -80,6 +81,7 @@ macro_rules! syscalls {
 syscalls!(
     // EVM opcodes
     (0x20, Keccak256, "keccak256"),
+    (0x30, Address, "address"),
     (0x32, Origin, "origin"),
     (0x33, Caller, "caller"),
     (0x34, CallValue, "callvalue"),


### PR DESCRIPTION
**Summary**

- Add `ADDRESS` syscall (0x30) and runtime helper for R55 contracts.
- R55 programs can now query the address of the currently executing contract using the new `address()` helper.
- Mirrors the EVM `ADDRESS` opcode.

**Changes**
- Add `Syscall::Address` (0x30) in eth-riscv-syscalls.
- Add `eth_riscv_runtime::address()` helper in eth-riscv-runtime for easy access.

**Impact**
- Only adds syscall surface and runtime helper.
- No changes to executor; that will be handled in a follow-up PR in the stack repo.
