### PR TITLE
fix: delegatecall uses appropriate registers for passing calldata size/offset

### DIFF
--- a/eth-riscv-runtime/src/call.rs
+++ b/eth-riscv-runtime/src/call.rs
@@ -131,7 +131,7 @@ pub fn delegatecall(addr: Address, data_offset: u64, data_size: u64) {
         asm!(
             "ecall",
             in("a0") addr[0], in("a1") addr[1], in("a2") addr[2],
-            in("a4") data_offset, in("a5") data_size,
+            in("a3") data_offset, in("a4") data_size,
             in("t0") u8::from(Syscall::DelegateCall)
         );
     }

--- a/eth-riscv-syscalls/src/lib.rs
+++ b/eth-riscv-syscalls/src/lib.rs
@@ -68,7 +68,7 @@ macro_rules! syscalls {
 // t0: 0x5A, opcode for gas (gasleft), returns 64-bit remaining gas in a0
 // t0: 0xf0, opcode for create, args: a0: 64-bit value, a1: calldata offset, a2: calldata size, returns an address
 // t0: 0xf1, opcode for call, args: a0-a2: address, a3: 64-bit value, a4: calldata offset, a5: calldata size
-// t0: 0xf4, opcode for delegatecall, args: a0-a2: address, a3: unused, a4: calldata offset, a5: calldata size
+// t0: 0xf4, opcode for delegatecall, args: a0-a2: address, a3: calldata offset, a4: calldata size
 // t0: 0xfa, opcode for staticcall, args: a0-a2: address, a3: 64-bit value, a4: calldata offset, a5: calldata size
 // t0: 0xf3, opcode for return, a0: memory address of data, a1: length of data in bytes, doesn't return
 // t0: 0xfd, opcode for revert, doesn't return


### PR DESCRIPTION
**Summary**

- Updated `delegatecall` to use `a3` for calldata offset and `a4` for calldata size (instead of `a4`/`a5`)
- Maintains register continuity without skipping `a3`
- `a5` is unused for delegatecall since it doesn't transfer value

**Changes**

- `eth-riscv-runtime/src/call.rs`: Updated `delegatecall` to pass offset in `a3`, size in `a4`
- `eth-riscv-syscalls/src/lib.rs`: Updated comment to reflect new register usage